### PR TITLE
Split public/private overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ Current status:
     - [x] UR5e
     - [ ] UR10
 - [ ] Controllers
-  - [x] Rolkneematics `panda-prosthesis`
+  - [x] Rolkneematics `panda-prosthesis` (through downstream flake in `panda-prosthesis` repository)
   - [ ] WIP: Hugo's polytopeController
 - [ ] `mc-mujoco`: building and running but some HiDPI scaling issues on Wayland with glfw 3.4
 - [ ] magnum packaging (external): in progress
   - [x] magnum
     - [x] SDL2Application: works
-    - [ ] GlfwApplication: HiDPI scaling issue on Wayland with GlfW 3.4, works otherwise
+    - [x] GlfwApplication:
+      - [ ]HiDPI scaling issue on Wayland with GlfW 3.4, works otherwise
   - [x] magnum-plugins (only those needed by `mc-rtc-magnum`/`mc-mujoco`
   - [x] magnum-integration
 

--- a/controller-shell.nix
+++ b/controller-shell.nix
@@ -44,7 +44,7 @@ let
   robot_module_paths = [ "${mc-rtc}/lib/mc_robots" ];
   controller_module_paths = [ "${mc-rtc}/lib/mc_controller" ];
   global_plugin_paths = [ "${mc-rtc}/lib/mc_plugins" ];
- 
+
   mc_rtc_yaml = pkgs.writeTextFile {
     name = "mc_rtc.yaml";
     text = ''
@@ -64,7 +64,9 @@ let
       RobotModulePaths: [${builtins.concatStringsSep "," (map (p: "\"${p}\"") robot_module_paths)}]
 
       ClearControllerModulePath: true
-      ControllerModulePaths: [${builtins.concatStringsSep "," (map (p: "\"${p}\"") controller_module_paths)}]
+      ControllerModulePaths: [${
+        builtins.concatStringsSep "," (map (p: "\"${p}\"") controller_module_paths)
+      }]
 
       ClearGlobalPluginPath: true
       GlobalPluginPaths: [${builtins.concatStringsSep "," (map (p: "\"${p}\"") global_plugin_paths)}]
@@ -73,7 +75,10 @@ let
 in
 
 pkgs.mkShell {
-  buildInputs = [ mc-rtc pkgs.clang-tools ];
+  buildInputs = [
+    mc-rtc
+    pkgs.clang-tools
+  ];
   shellHook = ''
     export TMP=/tmp
     export TMPDIR=/tmp
@@ -101,4 +106,3 @@ pkgs.mkShell {
     exit
   '';
 }
-

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,10 @@
           inherit (inputs) gepetto jrl-cmakemodulesv2;
           inherit enablePrivateOverlay;
         };
+        flakeModulePrivate = inputs.flake-parts.lib.importApply ./module.nix {
+          inherit (inputs) gepetto jrl-cmakemodulesv2;
+          enablePrivateOverlay = true;
+        };
       in
       {
         systems = import inputs.systems;
@@ -47,6 +51,7 @@
         ];
         flake = {
           inherit flakeModule;
+          inherit flakeModulePrivate;
           lib.mkFlakoboros =
             localInputs: module:
             inputs.flake-parts.lib.mkFlake { inputs = localInputs; } (args: {

--- a/flake.nix
+++ b/flake.nix
@@ -25,28 +25,29 @@
     ];
   };
 
-outputs = 
-  inputs:
-  inputs.flake-parts.lib.mkFlake { inherit inputs; } (
-  { lib, ...}:
-  let
-    flakeModule = inputs.flake-parts.lib.importApply ./module.nix {
-      inherit (inputs) gepetto jrl-cmakemodulesv2;
-    };
-  in
-  {
-      systems = import inputs.systems;
-      # systems =
-      # [
-      #   "x86_64-linux"
-      # ];
-      imports =
-      [
-        flakeModule
-      ];
-      flake = {
-        inherit flakeModule;
-        lib.mkFlakoboros =
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } (
+      { ... }:
+      let
+        enablePrivateOverlay = false;
+        flakeModule = inputs.flake-parts.lib.importApply ./module.nix {
+          inherit (inputs) gepetto jrl-cmakemodulesv2;
+          inherit enablePrivateOverlay;
+        };
+      in
+      {
+        systems = import inputs.systems;
+        # systems =
+        # [
+        #   "x86_64-linux"
+        # ];
+        imports = [
+          flakeModule
+        ];
+        flake = {
+          inherit flakeModule;
+          lib.mkFlakoboros =
             localInputs: module:
             inputs.flake-parts.lib.mkFlake { inputs = localInputs; } (args: {
               systems = import inputs.systems;
@@ -55,78 +56,112 @@ outputs =
                 { flakoboros = module args; }
               ];
             });
-      };
-      perSystem =
-        {
-          inputs', # per-system inputs
-          pkgs,
-          self',
-          system,
-          ...
-        }:
-        {
-        packages = inputs'.gepetto.packages // {
-          # Main dependencies
-          spacevecalg = pkgs.spacevecalg;
-          rbdyn = pkgs.rbdyn;
-          sch-core = pkgs.sch-core;
-          tasks = pkgs.tasks;
-          tvm = pkgs.tvm;
-          eigen-quadprog = pkgs.eigen-quadprog;
-          eigen-qld = pkgs.eigen-qld;
-          mc-rtc-data = pkgs.mc-rtc-data;
-          state-observation = pkgs.state-observation;
-          mesh-sampling = pkgs.mesh-sampling;
-          eigen-fmt = pkgs.eigen-fmt;
-
-          # Main GUIs and applications
-          mc-rtc-magnum = pkgs.mc-rtc-magnum;
-          mc-mujoco = pkgs.mc-mujoco;
-          mc-rtc-ticker = pkgs.mc-rtc-ticker;
-          # Control interfaces
-          mc-franka = pkgs.mc-franka;
-
-          # Main superbuild configurations
-          mc-rtc-superbuild = pkgs.mc-rtc-superbuild;
-          # Includes private repositories
-          mc-rtc-superbuild-full = pkgs.mc-rtc-superbuild-full;
-          # Todo: move those to their own project
-          mc-rtc-superbuild-rolkneematics = pkgs.mc-rtc-superbuild-rolkneematics;
-          mc-rtc-superbuild-hugo = pkgs.mc-rtc-superbuild-hugo;
-          # Main controllers
-          panda-prosthesis = pkgs.panda-prosthesis;
-          polytopeController = pkgs.polytopeController;
-
-          # Main plugins
-          mc-force-shoe-plugin = pkgs.mc-force-shoe-plugin;
-
-          # Main robots
-          mc-g1 = pkgs.mc-g1;
-          mc-h1 = pkgs.mc-h1;
-          mc-hrp2 = pkgs.mc-hrp2;
-          mc-hrp4 = pkgs.mc-hrp4;
-          mc-hrp5-p = pkgs.mc-hrp5-p;
-          # mc-rhps1 = pkgs.mc-rhps1;
-          mc-ur5e = pkgs.mc-ur5e;
-          mc-panda = pkgs.mc-panda;
-          mc-panda-lirmm = pkgs.mc-panda-lirmm;
         };
-          devShells = inputs'.gepetto.devShells
-          //
+        perSystem =
           {
-            mc-rtc-superbuild = import ./shell.nix
-            { 
-              inherit pkgs;
-              with-ros = true;
-              mc-rtc-superbuild = pkgs.mc-rtc-superbuild;
-            };
-            mc-rtc-superbuild-rolkneematics = import ./shell.nix
-            { 
-              inherit pkgs;
-              with-ros = true;
-              mc-rtc-superbuild = pkgs.mc-rtc-superbuild-rolkneematics;
-            };
+            inputs', # per-system inputs
+            pkgs,
+            ...
+          }:
+          {
+            packages =
+              inputs'.gepetto.packages
+              // {
+                # Main dependencies
+                spacevecalg = pkgs.spacevecalg;
+                rbdyn = pkgs.rbdyn;
+                sch-core = pkgs.sch-core;
+                tasks = pkgs.tasks;
+                tvm = pkgs.tvm;
+                eigen-quadprog = pkgs.eigen-quadprog;
+                eigen-qld = pkgs.eigen-qld;
+                state-observation = pkgs.state-observation;
+                mesh-sampling = pkgs.mesh-sampling;
+                eigen-fmt = pkgs.eigen-fmt;
+
+                # mc-rtc
+                mc-rtc-data = pkgs.mc-rtc-data;
+                mc-rtc = pkgs.mc-rtc;
+
+                # Main GUIs and applications
+                mc-rtc-magnum = pkgs.mc-rtc-magnum;
+                mc-mujoco = pkgs.mc-mujoco;
+                mc-rtc-ticker = pkgs.mc-rtc-ticker;
+                # Control interfaces
+                mc-franka = pkgs.mc-franka;
+
+                # Main superbuild configurations
+                mc-rtc-superbuild = pkgs.mc-rtc-superbuild;
+                # Includes private repositories
+                mc-rtc-superbuild-full = pkgs.mc-rtc-superbuild-full;
+                # Main controllers
+                panda-prosthesis = pkgs.panda-prosthesis;
+                polytopeController = pkgs.polytopeController;
+
+                # Main plugins
+                mc-force-shoe-plugin = pkgs.mc-force-shoe-plugin;
+
+                # Main robots
+                mc-g1 = pkgs.mc-g1;
+                mc-h1 = pkgs.mc-h1;
+                mc-ur5e = pkgs.mc-ur5e;
+                mc-panda = pkgs.mc-panda;
+                mc-panda-lirmm = pkgs.mc-panda-lirmm;
+              }
+              // (
+                if enablePrivateOverlay then
+                  {
+                    # Private robots
+                    mc-hrp2 = pkgs.mc-hrp2;
+                    mc-hrp4 = pkgs.mc-hrp4;
+                    mc-hrp5-p = pkgs.mc-hrp5-p;
+                    # Fixme this repository is far too big!
+                    mc-rhps1 = pkgs.mc-rhps1;
+
+                    # Superbuild configurations needing at least one private package
+                    mc-rtc-superbuild-private = pkgs.mc-rtc-superbuild-private;
+                    mc-rtc-superbuild-hugo = pkgs.mc-rtc-superbuild-hugo;
+                  }
+                else
+                  { }
+              );
+            devShells =
+              inputs'.gepetto.devShells
+              // {
+                mc-rtc-superbuild-minimal = import ./shell.nix {
+                  inherit pkgs;
+                  with-ros = true;
+                  mc-rtc-superbuild = pkgs.mc-rtc-superbuild-minimal;
+                };
+                mc-rtc-superbuild = import ./shell.nix {
+                  inherit pkgs;
+                  with-ros = true;
+                  mc-rtc-superbuild = pkgs.mc-rtc-superbuild;
+                };
+                mc-rtc-superbuild-all-public-robots = import ./shell.nix {
+                  inherit pkgs;
+                  with-ros = true;
+                  mc-rtc-superbuild = pkgs.mc-rtc-superbuild-all-public-robots;
+                };
+                mc-rtc-superbuild-full = import ./shell.nix {
+                  inherit pkgs;
+                  with-ros = true;
+                  mc-rtc-superbuild = pkgs.mc-rtc-superbuild-full;
+                };
+              }
+              // (
+                if enablePrivateOverlay then
+                  {
+                    mc-rtc-superbuild-private = import ./shell.nix {
+                      inherit pkgs;
+                      with-ros = true;
+                      mc-rtc-superbuild = pkgs.mc-rtc-superbuild-private;
+                    };
+                  }
+                else
+                  { }
+              );
           };
-        };
-  });
+      }
+    );
 }

--- a/module.nix
+++ b/module.nix
@@ -1,6 +1,7 @@
 {
   gepetto,
   jrl-cmakemodulesv2,
+  enablePrivateOverlay ? false,
   ...
 }:
 {
@@ -8,26 +9,33 @@
   self,
   ...
 }:
+let
+  privateOverlay =
+    if enablePrivateOverlay then
+      builtins.trace "Enabling private overlay" (final: prev: import ./overlay-private.nix { } final prev)
+    else
+      (_: _: { });
+in
 {
   imports = [ gepetto.flakeModule ];
 
   config = {
-    flake.overlays.mc-rtc-pkgs = import ./overlay.nix 
-    {
-      inherit lib; inherit jrl-cmakemodulesv2; 
+    flake.overlays.mc-rtc-pkgs = import ./overlay.nix {
+      inherit lib;
+      inherit jrl-cmakemodulesv2;
       with-ros = true;
       # FIXME: stop doing this and do proper flake.nix overrides in each package ;)
       useLocal = false;
       localWorkspace = "/home/arnaud/devel/mc-rtc-nix/workspace";
     };
-    flakoboros.overlays =
-    [
-      self.overlays.mc-rtc-pkgs 
-      (final: prev: { jrl-cmakemodulesv2 = jrl-cmakemodulesv2.packages.${prev.system}.default; })
+    flake.overlays.mc-rtc-private = privateOverlay;
+    flakoboros.overlays = [
+      self.overlays.mc-rtc-pkgs
+      self.overlays.mc-rtc-private
+      (_final: prev: { jrl-cmakemodulesv2 = jrl-cmakemodulesv2.packages.${prev.system}.default; })
     ];
     # Set permittedInsecurePackages for all pkgs instances
-    flakoboros.nixpkgsConfig =
-    {
+    flakoboros.nixpkgsConfig = {
       permittedInsecurePackages = [
         "openssl-1.1.1w"
       ];

--- a/overlay-ccache.nix
+++ b/overlay-ccache.nix
@@ -1,12 +1,16 @@
-{}:
+{ }:
 
-final: prev:
+_final: prev:
 let
-  withCCache = packages: with builtins; listToAttrs (map
-    (name: {
-      inherit name; value = (getAttr name prev).override { stdenv = prev.ccacheStdenv; };
-    })
-    packages);
+  withCCache =
+    packages:
+    with builtins;
+    listToAttrs (
+      map (name: {
+        inherit name;
+        value = (getAttr name prev).override { stdenv = prev.ccacheStdenv; };
+      }) packages
+    );
 in
 {
   ccacheWrapper = prev.ccacheWrapper.override {
@@ -40,7 +44,8 @@ in
       fi
     '';
   };
-} // withCCache [
+}
+// withCCache [
   "spacevecalg"
   "rbdyn"
   "sch-core"

--- a/overlay-private.nix
+++ b/overlay-private.nix
@@ -1,0 +1,70 @@
+{
+  with-ros ? true,
+  ...
+}:
+(
+  final: prev:
+  let
+    callWithRos = pkg: args: prev.callPackage pkg (args // { inherit with-ros; });
+  in
+  {
+    hrp2-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/hrp2-description.nix { };
+    hrp4-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/hrp4-description.nix { };
+    hrp5-p-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/hrp5-p-description.nix { };
+    rhps1-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/rhps1-description.nix { };
+    mc-hrp2 = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-hrp2.nix { };
+    mc-hrp4 = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-hrp4.nix { };
+    mc-hrp5-p = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-hrp5-p.nix { };
+    mc-rhps1 = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-rhps1.nix { };
+
+    rhps1-mj-description = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/rhps1-mj-description.nix { };
+    hrp4-mj-description = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/hrp4-mj-description.nix { };
+    hrp5p-mj-description = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/hrp5p-mj-description.nix { };
+    # TODO: hrp2-mj-description does not exist
+
+    # mc-mujoco with private robots
+    mc-mujoco-robots-private = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix {
+      robots = [
+        final.rhps1-mj-description
+        final.hrp4-mj-description
+        final.hrp5p-mj-description
+        # NOTE: hrp2-mj-description does not exist
+      ];
+    };
+
+    mc-mujoco-full = prev.callPackage ./pkgs/mc-rtc/mc-mujoco {
+      jrl-cmakemodules = final.jrl-cmakemodulesv2;
+      mc-mujoco-robots = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix {
+        robots = final.mc-mujoco-robots-public ++ final.mc-mujoco-robots-private;
+      };
+    };
+
+    mc-rtc-superbuild-private = prev.callPackage ./pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix {
+      superbuildArgs = prev.mc-rtc-superbuild-full.superbuildArgs // {
+        pname = "mc-rtc-superbuild-private";
+        robots = prev.mc-rtc-superbuild-full.superbuildArgs.robots ++ [
+          final.mc-hrp2
+          final.mc-hrp4
+          final.mc-hrp5-p
+          # final.mc-rhps1
+        ];
+      };
+    };
+
+    # TODO move to Hugo's
+    mc-rtc-superbuild-hugo = prev.callPackage ./pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix {
+      superbuildArgs = prev.mc-rtc-superbuild-full.superbuildArgs // {
+        pname = "mc-rtc-superbuild-hugo";
+        robots = [ final.mc-rhps1 ];
+        # observers = [mc-state-observation]; # FIXME missing Attitude observer from mc_state_observation
+        controllers = [ final.polytopeController ];
+        configs = [ "${final.polytopeController}/lib/mc_controller/etc/mc_rtc.yaml" ];
+        plugins = [ final.mc-force-shoe-plugin-hugo ];
+        apps = [
+          final.mc-rtc-magnum-hugo
+          final.mc-mujoco-hugo
+        ];
+      };
+    };
+  }
+)

--- a/overlay.nix
+++ b/overlay.nix
@@ -138,49 +138,25 @@
     # mc-rtc-magnum = prev.callPackage ./pkgs/mc-rtc-magnum {};
     gram-savitzky-golay = prev.callPackage ./pkgs/gram-savitzky-golay { };
 
-    ######################
-    # Overrides for hugo #
-    # polytopeController #
-    ######################
-    mc-rtc-hugo = final.mc-rtc.overrideAttrs (_old: {
-      tvm = final.tvm-hugo;
-      src = final.fetchgit {
-        url = "https://github.com/arntanguy/mc_rtc.git";
-        rev = "73b10e8d7db6671e901d16f6ec9cde299c07ba4d";
-        sha256 = "sha256-MJrulDf6Qm8esLLJxIZoLerG3p/ug5M9WnMYoonHtrw=";
-      };
-      pname = "mc-rtc-hugo";
-    });
-
-    tvm-hugo = final.tvm.overrideAttrs (_old: {
-      src = final.fetchgit {
-        # tvm pr 53
-        url = "https://github.com/Hugo-L3174/tvm.git";
-        rev = "0c66fac37db38f2e5bc4f3df2b418f3ae50cea68";
-        sha256 = "sha256-wLalEmtXO4Id8PFtVoJD9KzCU4QKeAv/xp5mCjDvpnA=";
-      };
-    });
-    mc-rtc-magnum-hugo = final.mc-rtc-magnum.overrideAttrs (_old: {
-      mc-rtc = final.mc-rtc-hugo;
-    });
-    mc-mujoco-hugo = final.mc-mujoco-full.overrideAttrs (_old: {
-      mc-rtc = final.mc-rtc-hugo;
-    });
-    mc-force-shoe-plugin-hugo = final.mc-force-shoe-plugin.overrideAttrs (_old: {
-      mc-rtc = final.mc-rtc-hugo;
-    });
-    polytopeController = callWithLocal ./pkgs/mc-rtc/controllers/polytopeController { };
-    #mc-dynamic-polytopes = prev.callPackage ./pkgs/mc-rtc/controllers/polytopeController/mc-dynamic-polytopes.nix {};
-    mc-dynamic-polytopes =
-      callWithLocal ./pkgs/mc-rtc/controllers/polytopeController/mc-dynamic-polytopes.nix
-        {
-          jrl-cmakemodules = final.jrl-cmakemodulesv2;
-          mc-rtc = final.mc-rtc-hugo;
-        };
+    # Hugo's dependencies
+    # FIXME: { won't build as-is here as it requires a branch of mc-rtc for now
+    # See https://github.com/Hugo-L3174/polytopeController's flake.nix
+    # As they are currently not in the flake.nix's package set, this is probably ok to
+    # have non-building versions in the overlay (?)
+    mc-dynamic-polytopes = prev.callPackage ./pkgs/mc-rtc/controllers/polytopeController/mc-dynamic-polytopes.nix
+    {
+      jrl-cmakemodules = final.jrl-cmakemodulesv2;
+      # mc-rtc = final.mc-rtc-hugo;
+    };
     dcm-vrptask = callWithLocal ./pkgs/mc-rtc/controllers/polytopeController/dcm-vrptask.nix {
-      mc-rtc = final.mc-rtc-hugo;
+      # mc-rtc = final.mc-rtc-hugo;
       jrl-cmakemodules = final.jrl-cmakemodulesv2;
     };
+    polytopeController = prev.callPackage ./pkgs/mc-rtc/controllers/polytopeController/default.nix {
+      # mc-rtc = final.mc-rtc-hugo;
+    };
+    # End of Hugo's dependencies
+    # } end of FIXME
 
     ##########
     #  Apps  #

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,332 +1,341 @@
 /**
-- **`final`**: The package set after all overlays have been applied.
-  Use this if you want to reference packages as they will appear after your overlay and others are merged.
+  - **`final`**: The package set after all overlays have been applied.
+    Use this if you want to reference packages as they will appear after your overlay and others are merged.
 
-- **`prev`**: The package set before your overlay is applied (i.e., the "previous" state).
-  Use this to access and override existing packages, or to call functions from the underlying package set.
+  - **`prev`**: The package set before your overlay is applied (i.e., the "previous" state).
+    Use this to access and override existing packages, or to call functions from the underlying package set.
 */
-{ useLocal ? false, localWorkspace ? null, with-ros ? false, ... }:
-(final: prev:
-let
-  callWithLocal = pkg: { ... }@args:
-    prev.callPackage pkg ({
-      inherit useLocal localWorkspace;
-    } // args);
-  callWithRos = pkg: args: prev.callPackage pkg (args // { inherit with-ros; });
-  callWithRosLocal = pkg: args: prev.callPackage pkg (args // { inherit with-ros useLocal localWorkspace; });
-in rec
 {
-  inherit (prev.rosPackages.jazzy)
-    buildRosPackage
-    ament-cmake
-    rclcpp
-    ros2cli
-    ros2run
-    ros2launch
-    ros2topic
-    rosbag2
-    rviz2
-    nav-msgs
-    tf2-ros
-    visualization-msgs
-    sensor-msgs
-    rosidl-default-generators
-    rosidl-default-runtime
-    rosidl-typesupport-c
-    rosidl-typesupport-cpp
-    geometry-msgs
-    xacro;
+  useLocal ? false,
+  localWorkspace ? null,
+  with-ros ? false,
+  ...
+}:
+(
+  final: prev:
+  let
+    callWithLocal =
+      pkg:
+      { ... }@args:
+      prev.callPackage pkg (
+        {
+          inherit useLocal localWorkspace;
+        }
+        // args
+      );
+    callWithRos = pkg: args: prev.callPackage pkg (args // { inherit with-ros; });
+  in
+  {
+    inherit (prev.rosPackages.jazzy)
+      buildRosPackage
+      ament-cmake
+      rclcpp
+      ros2cli
+      ros2run
+      ros2launch
+      ros2topic
+      rosbag2
+      rviz2
+      nav-msgs
+      tf2-ros
+      visualization-msgs
+      sensor-msgs
+      rosidl-default-generators
+      rosidl-default-runtime
+      rosidl-typesupport-c
+      rosidl-typesupport-cpp
+      geometry-msgs
+      xacro
+      ;
 
-  nanomsg = prev.nanomsg.overrideAttrs (old: rec {
-    postPatch = ''
-      substituteInPlace cmake/nanomsg-config.cmake.in \
-        --replace '@PACKAGE_CMAKE_INSTALL_PREFIX@/' ""
-    '';
-  });
+    nanomsg = prev.nanomsg.overrideAttrs (_old: rec {
+      postPatch = ''
+        substituteInPlace cmake/nanomsg-config.cmake.in \
+          --replace '@PACKAGE_CMAKE_INSTALL_PREFIX@/' ""
+      '';
+    });
 
-  spacevecalg = prev.callPackage ./pkgs/spacevecalg {};
-  rbdyn = prev.callPackage ./pkgs/rbdyn {};
-  eigen-qld = prev.callPackage ./pkgs/eigen-qld {};
-  eigen-quadprog = prev.callPackage ./pkgs/eigen-quadprog {};
-  sch-core = prev.callPackage ./pkgs/sch-core {};
-  #sch-visualization = prev.callPackage ./pkgs/sch-visualization {};
-  sch-visualization = callWithLocal ./pkgs/sch-visualization {};
-  tasks = prev.callPackage ./pkgs/tasks {};
-  # mc-rtc-data = prev.callPackage ./pkgs/mc-rtc-data { with-ros = false; };
-  mc-rtc-data = callWithRos ./pkgs/mc-rtc-data {};
-  state-observation = prev.callPackage ./pkgs/state-observation {};
-  mc-rbdyn-urdf = prev.callPackage ./pkgs/mc-rbdyn-urdf {};
-  tvm = prev.callPackage ./pkgs/tvm {};
-  copra = prev.callPackage ./pkgs/copra {};
-  omniorb = prev.symlinkJoin {
-    name = "omniorb";
-    paths = [
-      prev.omniorb.out
-      (prev.callPackage ./pkgs/omniorb-python {
-        omniorb = prev.omniorb;
-        buildPythonPackage = prev.python2Packages.buildPythonPackage;
-      }).out
-    ];
-  };
-  openrtm-aist = prev.callPackage ./pkgs/openrtm-aist {};
-  openrtm-aist-python = prev.callPackage ./pkgs/openrtm-aist-python {
-    buildPythonPackage = prev.python2Packages.buildPythonPackage;
-  };
-  # mc-state-observation = callWithLocal ./pkgs/mc-rtc/observers/mc-state-observation;
-  mc-state-observation = prev.callPackage ./pkgs/mc-rtc/observers/mc-state-observation {};
-  #lipm-walking-controller = prev.callPackage ./pkgs/mc-rtc/controllers/lipm-walking-controller {};
-  # lipm-walking-controller = callWithLocal ./pkgs/mc-rtc/controllers/lipm-walking-controller {};
-  #mc-rtc-raylib = prev.callPackage ./pkgs/mc-rtc-raylib {};
-  mc-rtc-msgs = prev.callPackage ./pkgs/mc-rtc-msgs {};
-  mc-udp = prev.callPackage ./pkgs/mc-udp {};
-
-  ## Robot description packages
-  franka-description = prev.callPackage ./pkgs/mc-rtc/robots/mc-panda/franka-description.nix {};
-  g1-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/g1-description.nix {};
-  h1-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/h1-description.nix {};
-  hrp2-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/hrp2-description.nix {};
-  hrp4-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/hrp4-description.nix {};
-  hrp5-p-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/hrp5-p-description.nix {};
-  ur-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/ur-description.nix {};
-  ur5e-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/ur5e-description.nix {};
-  jvrc-description = callWithRos ./pkgs/mc-rtc-data/jvrc-description.nix {};
-  mc-env-description = callWithRos ./pkgs/mc-rtc-data/mc-env-description.nix {};
-  mc-int-obj-description = callWithRos ./pkgs/mc-rtc-data/mc-int-obj-description.nix {};
-  rhps1-description = callWithRosLocal ./pkgs/mc-rtc/robots/descriptions/rhps1-description.nix {};
-
-  # Robot modules
-  mc-g1 = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-g1.nix { };
-  mc-h1 = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-h1.nix { };
-  mc-hrp2 = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-hrp2.nix { };
-  mc-hrp4 = callWithLocal ./pkgs/mc-rtc/robots/modules/mc-hrp4.nix {};
-  mc-hrp5-p = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-hrp5-p.nix {};
-  mc-ur5e = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-ur5e.nix { };
-  mc-panda = callWithLocal ./pkgs/mc-rtc/robots/mc-panda {};
-  mc-panda-lirmm = callWithLocal ./pkgs/mc-rtc/robots/mc-panda/mc-panda-lirmm.nix {};
-  mc-rhps1 = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-rhps1.nix {};
-
-  libfranka = prev.callPackage ./pkgs/mc-rtc/robots/mc-panda/libfranka.nix {};
-  # mc-franka = prev.callPackage ./pkgs/mc-rtc/robots/mc-panda/mc-franka.nix {};
-  mc-franka = callWithLocal ./pkgs/mc-rtc/robots/mc-panda/mc-franka.nix {};
-  poco = prev.callPackage ./pkgs/mc-rtc/robots/mc-panda/libpoco.nix {};
-  mesh-sampling = prev.callPackage ./pkgs/mesh-sampling {};
-  # mesh-sampling = callWithLocal ./pkgs/mesh-sampling {};
-
-  # XXX
-  # The current nixpkgs input uses fmt_12
-  # This breaks both eigen-fmt and PTransformd
-  # In mc-rtc fmt is brought in through spdlog. Thus we build an older version
-  # 1.12.0 against fmt_9 (technically it supports fmt_10 but nixpkgs used to build it against fmt_9 on purpose). To avoid rebuilding the world, we leave fmt_12 everywhere else,
-  # this might cause some headache down the line.
-  # TODO: patch mc-rtc and eigen-fmt with fmt_12 support
-  mc-rtc = callWithRos ./pkgs/mc-rtc/mc-rtc.nix {
-    spdlog = prev.callPackage ./pkgs/spdlog-1.12.0.nix {
-      fmt = final.fmt_9;
-    };
-  };
-  mc-rtc-python-utils = callWithLocal ./pkgs/mc-rtc/mc-rtc-python-utils.nix {};
-  #mc-rtc = callWithRos ./pkgs/mc-rtc/mc-rtc.nix {};
-  # mc-rtc-rviz-panel = prev.libsForQt5.callPackage ./pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix { inherit useLocal; inherit localWorkspace; };
-  mc-rtc-rviz-panel = prev.libsForQt5.callPackage ./pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix {};
-  # mc-rtc-ticker = callWithLocal ./pkgs/mc-rtc/ros/mc-rtc-ticker.nix {};
-  mc-rtc-ticker = prev.callPackage ./pkgs/mc-rtc/ros/mc-rtc-ticker.nix {};
-  # mc-rtc = callWithLocal ./pkgs/mc-rtc/mc-rtc.nix { with-ros = true; };
-  # mc-rtc = prev.callPackage ./pkgs/mc-rtc/mc-rtc.nix { };
-  # mc-rtc-magnum = prev.callPackage ./pkgs/mc-rtc-magnum {};
-  gram-savitzky-golay = prev.callPackage ./pkgs/gram-savitzky-golay {};
-
-  ######################
-  # Overrides for hugo #
-  # polytopeController #
-  ######################
-  mc-rtc-hugo = final.mc-rtc.overrideAttrs (old: {
-    tvm = final.tvm-hugo;
-    src = final.fetchgit {
-      url = "https://github.com/arntanguy/mc_rtc.git";
-      rev = "73b10e8d7db6671e901d16f6ec9cde299c07ba4d";
-      sha256 = "sha256-MJrulDf6Qm8esLLJxIZoLerG3p/ug5M9WnMYoonHtrw=";
-    };
-    pname = "mc-rtc-hugo";
-  });
-
-  tvm-hugo = final.tvm.overrideAttrs (old: {
-    src = final.fetchgit {
-      # tvm pr 53
-      url = "https://github.com/Hugo-L3174/tvm.git";
-      rev = "0c66fac37db38f2e5bc4f3df2b418f3ae50cea68";
-      sha256 = "sha256-wLalEmtXO4Id8PFtVoJD9KzCU4QKeAv/xp5mCjDvpnA=";
-    };
-  });
-  mc-rtc-magnum-hugo = final.mc-rtc-magnum.overrideAttrs (old: {
-    mc-rtc = final.mc-rtc-hugo;
-  });
-  mc-mujoco-hugo = final.mc-mujoco-full.overrideAttrs (old: {
-    mc-rtc = final.mc-rtc-hugo;
-  });
-  mc-force-shoe-plugin-hugo = final.mc-force-shoe-plugin.overrideAttrs (old: {
-    mc-rtc = final.mc-rtc-hugo;
-  });
-  polytopeController = callWithLocal ./pkgs/mc-rtc/controllers/polytopeController {};
-  #mc-dynamic-polytopes = prev.callPackage ./pkgs/mc-rtc/controllers/polytopeController/mc-dynamic-polytopes.nix {};
-  mc-dynamic-polytopes = callWithLocal ./pkgs/mc-rtc/controllers/polytopeController/mc-dynamic-polytopes.nix {
-    jrl-cmakemodules = final.jrl-cmakemodulesv2;
-    mc-rtc = final.mc-rtc-hugo;
-  };
-  dcm-vrptask = callWithLocal ./pkgs/mc-rtc/controllers/polytopeController/dcm-vrptask.nix {
-    mc-rtc = final.mc-rtc-hugo;
-    jrl-cmakemodules = final.jrl-cmakemodulesv2;
-  };
-
-  ##########
-  #  Apps  #
-  ##########
-  mujoco = prev.mujoco.overrideAttrs (old: {
-    propagatedBuildInputs = (old.propagatedBuildInputs or []) ++ [ final.libGL ];
-  });
-
-  jvrc1-mj-description = callWithLocal ./pkgs/mc-rtc/mc-mujoco/robots/jvrc1-mj-description.nix {};
-  rhps1-mj-description = callWithLocal ./pkgs/mc-rtc/mc-mujoco/robots/rhps1-mj-description.nix {};
-  g1-mj-description = final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/g1-mj-description.nix {};
-  h1-mj-description = callWithLocal ./pkgs/mc-rtc/mc-mujoco/robots/h1-mj-description.nix {};
-  hrp4-mj-description = callWithLocal ./pkgs/mc-rtc/mc-mujoco/robots/hrp4-mj-description.nix {};
-  # TODO: hrp2-mj-description does not exist
-  #hrp5p-mj-description = final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/hrp5p-mj-description.nix {};
-  hrp5p-mj-description = callWithLocal ./pkgs/mc-rtc/mc-mujoco/robots/hrp5p-mj-description.nix {};
-  ur5e-mj-description = final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/ur5e-mj-description.nix {};
-
-  env-mj-description = callWithLocal ./pkgs/mc-rtc/mc-mujoco/robots/env-mj-description.nix {};
-
-  # symlinkJoin all robots
-  # FIXME: this triggers a full rebuild of mc-mujoco
-  mc-mujoco = callWithLocal ./pkgs/mc-rtc/mc-mujoco {
-    jrl-cmakemodules = final.jrl-cmakemodulesv2;
-  };
-
-  # mc-mujoco with private robots
-  mc-mujoco-robots-full = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix {
-    robots = [
-      rhps1-mj-description
-      g1-mj-description
-      h1-mj-description
-      hrp4-mj-description
-      hrp5p-mj-description
-      rhps1-mj-description
-      ur5e-mj-description
-      # NOTE: hrp2-mj-description does not exist
+    spacevecalg = prev.callPackage ./pkgs/spacevecalg { };
+    rbdyn = prev.callPackage ./pkgs/rbdyn { };
+    eigen-qld = prev.callPackage ./pkgs/eigen-qld { };
+    eigen-quadprog = prev.callPackage ./pkgs/eigen-quadprog { };
+    sch-core = prev.callPackage ./pkgs/sch-core { };
+    #sch-visualization = prev.callPackage ./pkgs/sch-visualization {};
+    sch-visualization = callWithLocal ./pkgs/sch-visualization { };
+    tasks = prev.callPackage ./pkgs/tasks { };
+    # mc-rtc-data = prev.callPackage ./pkgs/mc-rtc-data { with-ros = false; };
+    mc-rtc-data = callWithRos ./pkgs/mc-rtc-data { };
+    state-observation = prev.callPackage ./pkgs/state-observation { };
+    mc-rbdyn-urdf = prev.callPackage ./pkgs/mc-rbdyn-urdf { };
+    tvm = prev.callPackage ./pkgs/tvm { };
+    copra = prev.callPackage ./pkgs/copra { };
+    omniorb = prev.symlinkJoin {
+      name = "omniorb";
+      paths = [
+        prev.omniorb.out
+        (prev.callPackage ./pkgs/omniorb-python {
+          omniorb = prev.omniorb;
+          buildPythonPackage = prev.python2Packages.buildPythonPackage;
+        }).out
       ];
-  };
-  mc-mujoco-robots = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix {};
-  mc-mujoco-full = callWithLocal ./pkgs/mc-rtc/mc-mujoco {
-    jrl-cmakemodules = final.jrl-cmakemodulesv2;
-    mc-mujoco-robots = mc-mujoco-robots-full;
-  };
+    };
+    openrtm-aist = prev.callPackage ./pkgs/openrtm-aist { };
+    openrtm-aist-python = prev.callPackage ./pkgs/openrtm-aist-python {
+      buildPythonPackage = prev.python2Packages.buildPythonPackage;
+    };
+    # mc-state-observation = callWithLocal ./pkgs/mc-rtc/observers/mc-state-observation;
+    mc-state-observation = prev.callPackage ./pkgs/mc-rtc/observers/mc-state-observation { };
+    #lipm-walking-controller = prev.callPackage ./pkgs/mc-rtc/controllers/lipm-walking-controller {};
+    # lipm-walking-controller = callWithLocal ./pkgs/mc-rtc/controllers/lipm-walking-controller {};
+    #mc-rtc-raylib = prev.callPackage ./pkgs/mc-rtc-raylib {};
+    mc-rtc-msgs = prev.callPackage ./pkgs/mc-rtc-msgs { };
+    mc-udp = prev.callPackage ./pkgs/mc-udp { };
 
-  ###############
-  # CONTROLLERS #
-  ###############
-  panda-prosthesis = callWithLocal ./pkgs/mc-rtc/controllers/panda-prosthesis {};
-  # panda-prosthesis = prev.callPackage ./pkgs/mc-rtc/controllers/panda-prosthesis {};
+    ## Robot description packages
+    franka-description = prev.callPackage ./pkgs/mc-rtc/robots/mc-panda/franka-description.nix { };
+    g1-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/g1-description.nix { };
+    h1-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/h1-description.nix { };
+    ur-description = prev.callPackage ./pkgs/mc-rtc/robots/descriptions/ur-description.nix { };
+    ur5e-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/ur5e-description.nix { };
+    jvrc-description = callWithRos ./pkgs/mc-rtc-data/jvrc-description.nix { };
+    mc-env-description = callWithRos ./pkgs/mc-rtc-data/mc-env-description.nix { };
+    mc-int-obj-description = callWithRos ./pkgs/mc-rtc-data/mc-int-obj-description.nix { };
 
-  ###########
-  # PLUGINS #
-  ###########
-  mc-force-shoe-plugin = callWithLocal ./pkgs/mc-rtc/plugins/mc-force-shoe-plugin.nix {};
-  mc-robot-model-update = callWithLocal ./pkgs/mc-rtc/plugins/mc-robot-model-update.nix {};
+    # Robot modules
+    mc-g1 = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-g1.nix { };
+    mc-h1 = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-h1.nix { };
+    mc-ur5e = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-ur5e.nix { };
+    mc-panda = callWithLocal ./pkgs/mc-rtc/robots/mc-panda { };
+    mc-panda-lirmm = callWithLocal ./pkgs/mc-rtc/robots/mc-panda/mc-panda-lirmm.nix { };
 
-  #############
-  # 3rd-party #
-  #############
-  eigen-fmt = prev.callPackage ./pkgs/3rd-party/eigen-fmt {
-    fmt = prev.fmt_10;
-  };
-  politopix = prev.callPackage ./pkgs/3rd-party/politopix.nix {
-    fetchurl = final.stdenv.fetchurlBoot;
-  };
+    libfranka = prev.callPackage ./pkgs/mc-rtc/robots/mc-panda/libfranka.nix { };
+    # mc-franka = prev.callPackage ./pkgs/mc-rtc/robots/mc-panda/mc-franka.nix {};
+    mc-franka = callWithLocal ./pkgs/mc-rtc/robots/mc-panda/mc-franka.nix { };
+    poco = prev.callPackage ./pkgs/mc-rtc/robots/mc-panda/libpoco.nix { };
+    mesh-sampling = prev.callPackage ./pkgs/mesh-sampling { };
+    # mesh-sampling = callWithLocal ./pkgs/mesh-sampling {};
 
-  imguizmo = callWithLocal ./pkgs/3rd-party/imguizmo.nix {
-    jrl-cmakemodules = final.jrl-cmakemodulesv2;
-  };
-  corrade = prev.callPackage ./pkgs/3rd-party/magnum/corrade.nix {};
-  magnum = prev.callPackage ./pkgs/3rd-party/magnum/magnum.nix {};
-  magnum-integration = callWithLocal ./pkgs/3rd-party/magnum/magnum-integration.nix {
-    with-imguiintegration = true;
-  };
-  magnum-plugins = callWithLocal ./pkgs/3rd-party/magnum/magnum-plugins.nix {
-    magnumPluginsWithAssimpImporter = true;
-    magnumPluginsWithStbImageImporter = true;
-  };
-  magnum-with-plugins = prev.callPackage ./pkgs/3rd-party/magnum/magnum-with-plugins.nix {};
-  mc-rtc-imgui = callWithLocal ./pkgs/mc-rtc-imgui {
-    jrl-cmakemodules = final.jrl-cmakemodulesv2;
-  };
-  # standlone version of mc-rtc-magnum, with independent packaging for magnum and its plugins
-  # and a standalone mc-rtc-imgui version
-  mc-rtc-magnum = prev.callPackage ./pkgs/mc-rtc-magnum/standalone.nix {};
+    # XXX
+    # The current nixpkgs input uses fmt_12
+    # This breaks both eigen-fmt and PTransformd
+    # In mc-rtc fmt is brought in through spdlog. Thus we build an older version
+    # 1.12.0 against fmt_9 (technically it supports fmt_10 but nixpkgs used to build it against fmt_9 on purpose). To avoid rebuilding the world, we leave fmt_12 everywhere else,
+    # this might cause some headache down the line.
+    # TODO: patch mc-rtc and eigen-fmt with fmt_12 support
+    mc-rtc = callWithRos ./pkgs/mc-rtc/mc-rtc.nix {
+      spdlog = prev.callPackage ./pkgs/spdlog-1.12.0.nix {
+        fmt = final.fmt_9;
+      };
+    };
+    mc-rtc-python-utils = callWithLocal ./pkgs/mc-rtc/mc-rtc-python-utils.nix { };
+    #mc-rtc = callWithRos ./pkgs/mc-rtc/mc-rtc.nix {};
+    # mc-rtc-rviz-panel = prev.libsForQt5.callPackage ./pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix { inherit useLocal; inherit localWorkspace; };
+    mc-rtc-rviz-panel = prev.libsForQt5.callPackage ./pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix { };
+    # mc-rtc-ticker = callWithLocal ./pkgs/mc-rtc/ros/mc-rtc-ticker.nix {};
+    mc-rtc-ticker = prev.callPackage ./pkgs/mc-rtc/ros/mc-rtc-ticker.nix { };
+    # mc-rtc = callWithLocal ./pkgs/mc-rtc/mc-rtc.nix { with-ros = true; };
+    # mc-rtc = prev.callPackage ./pkgs/mc-rtc/mc-rtc.nix { };
+    # mc-rtc-magnum = prev.callPackage ./pkgs/mc-rtc-magnum {};
+    gram-savitzky-golay = prev.callPackage ./pkgs/gram-savitzky-golay { };
 
-  #####################
-  # mc-rtc-superbuild #
-  #####################
-  # This derivation provides a mechanism to bring configurations of the whole framework together,
-  # that is:
-  # - mc-rtc itself
-  # - all runtime dependencies controllers/robots/observers/plugins required by the user
-  # - a default mc-rtc configuration, e.g which controller/timestep/main robot to use, or if the controllers
-  #   provide a suitable mc_rtc.yaml file, it can be referenced here as well
-  #
-  # This is handled as follows:
-  # - all runtime dependencies (including mc-rtc) are built independently, and their output is merged together (symlinkJoin) into a single runtimepath
-  # - the default mc_rtc.yaml runtime paths are overridden with corresponding paths in the merged output such that all runtime dependencies are available at the same place (this avoids confusion as to where each runtime dependency is located in the store and makes for a more user-friendly approach). In practice mc_rtc loads this mc_rtc.yaml override through the MC_RTC_CONTROLLER_CONFIG environment variable
-  #
-  # Note that local out-of-nix overrides from local source folders of controller/robot/plugin/observers can be achieved by:
-  # - prefixing LD_LIBRARY_PATH with the local intalled lib path
-  # - providing a custom mc_rtc.yaml with ControllerModulePaths, ObserverModulePaths, etc pointing to their corresponding installed folder
-  # This is not per-say recomended, but it can drastically reduce build time for these components, and also allow for seamless LSP integration in your editor.
-  #
-  # TODO: investigate use of ccacheStdenv
-  # mc-rtc-superbuild = prev.callPackage ./pkgs/mc-rtc/mc-rtc-superbuild-symlinkjoin.nix.nix { 
+    ######################
+    # Overrides for hugo #
+    # polytopeController #
+    ######################
+    mc-rtc-hugo = final.mc-rtc.overrideAttrs (_old: {
+      tvm = final.tvm-hugo;
+      src = final.fetchgit {
+        url = "https://github.com/arntanguy/mc_rtc.git";
+        rev = "73b10e8d7db6671e901d16f6ec9cde299c07ba4d";
+        sha256 = "sha256-MJrulDf6Qm8esLLJxIZoLerG3p/ug5M9WnMYoonHtrw=";
+      };
+      pname = "mc-rtc-hugo";
+    });
 
-  # default superbuild environment
-  mc-rtc-superbuild = final.callPackage ./pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix { 
-    apps = [ mc-rtc-magnum mc-mujoco mc-rtc-ticker ];
-  };
+    tvm-hugo = final.tvm.overrideAttrs (_old: {
+      src = final.fetchgit {
+        # tvm pr 53
+        url = "https://github.com/Hugo-L3174/tvm.git";
+        rev = "0c66fac37db38f2e5bc4f3df2b418f3ae50cea68";
+        sha256 = "sha256-wLalEmtXO4Id8PFtVoJD9KzCU4QKeAv/xp5mCjDvpnA=";
+      };
+    });
+    mc-rtc-magnum-hugo = final.mc-rtc-magnum.overrideAttrs (_old: {
+      mc-rtc = final.mc-rtc-hugo;
+    });
+    mc-mujoco-hugo = final.mc-mujoco-full.overrideAttrs (_old: {
+      mc-rtc = final.mc-rtc-hugo;
+    });
+    mc-force-shoe-plugin-hugo = final.mc-force-shoe-plugin.overrideAttrs (_old: {
+      mc-rtc = final.mc-rtc-hugo;
+    });
+    polytopeController = callWithLocal ./pkgs/mc-rtc/controllers/polytopeController { };
+    #mc-dynamic-polytopes = prev.callPackage ./pkgs/mc-rtc/controllers/polytopeController/mc-dynamic-polytopes.nix {};
+    mc-dynamic-polytopes =
+      callWithLocal ./pkgs/mc-rtc/controllers/polytopeController/mc-dynamic-polytopes.nix
+        {
+          jrl-cmakemodules = final.jrl-cmakemodulesv2;
+          mc-rtc = final.mc-rtc-hugo;
+        };
+    dcm-vrptask = callWithLocal ./pkgs/mc-rtc/controllers/polytopeController/dcm-vrptask.nix {
+      mc-rtc = final.mc-rtc-hugo;
+      jrl-cmakemodules = final.jrl-cmakemodulesv2;
+    };
 
-  mc-rtc-superbuild-full = final.callPackage ./pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix { 
-    robots = [
-      mc-g1
-      mc-h1
-      mc-hrp2
-      mc-hrp4
-      mc-hrp5-p
-      mc-rhps1
-      mc-ur5e
-    ];
-    #apps = [ mc-rtc-magnum mc-mujoco mc-rtc-ticker ];
-    apps = [ mc-rtc-magnum mc-mujoco ];
-  };
+    ##########
+    #  Apps  #
+    ##########
+    mujoco = prev.mujoco.overrideAttrs (old: {
+      propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ final.libGL ];
+    });
 
-  # TODO: move to rolkneematic's panda_prosthesis repository
-  mc-rtc-superbuild-rolkneematics = prev.callPackage ./pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix { 
-    robots = [
-      # note that panda-prosthesis is not strictly-speaking a robot, but it builds a robot module so we need it here as well to populate the robots runtime paths
-      panda-prosthesis
-      mc-panda-lirmm
-      mc-panda
-    ];
-    controllers = [ panda-prosthesis ];
-    # extra mc_rtc.yaml
-    configs = [ "${panda-prosthesis}/lib/mc_controller/etc/mc_rtc.yaml" ];
-    observers = [];
-    plugins = [ panda-prosthesis ];
-    apps = [ mc-rtc-magnum mc-franka mc-rtc-ticker ];
-  };
+    jvrc1-mj-description = callWithLocal ./pkgs/mc-rtc/mc-mujoco/robots/jvrc1-mj-description.nix { };
+    g1-mj-description = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/g1-mj-description.nix { };
+    h1-mj-description = callWithLocal ./pkgs/mc-rtc/mc-mujoco/robots/h1-mj-description.nix { };
+    ur5e-mj-description = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/ur5e-mj-description.nix { };
 
-  # TODO move to Hugo's
-  mc-rtc-superbuild-hugo = prev.callPackage ./pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix { 
-    robots = [ mc-rhps1 ];
-    # observers = [mc-state-observation]; # FIXME missing Attitude observer from mc_state_observation
-    controllers = [polytopeController];
-    configs = [ "${polytopeController}/lib/mc_controller/etc/mc_rtc.yaml" ];
-    plugins = [ mc-force-shoe-plugin-hugo ];
-    apps = [ mc-rtc-magnum-hugo mc-mujoco-hugo ];
-  };
-})
+    env-mj-description = callWithLocal ./pkgs/mc-rtc/mc-mujoco/robots/env-mj-description.nix { };
+
+    # symlinkJoin all robots
+    # FIXME: this triggers a full rebuild of mc-mujoco
+    mc-mujoco = callWithLocal ./pkgs/mc-rtc/mc-mujoco {
+      jrl-cmakemodules = final.jrl-cmakemodulesv2;
+    };
+
+    mc-mujoco-robots = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix { };
+    # mc-mujoco with all public robots
+    mc-mujoco-robots-public = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix {
+      robots = [
+        final.g1-mj-description
+        final.h1-mj-description
+        final.ur5e-mj-description
+      ];
+    };
+
+    ###############
+    # CONTROLLERS #
+    ###############
+    panda-prosthesis = callWithLocal ./pkgs/mc-rtc/controllers/panda-prosthesis { };
+    # panda-prosthesis = prev.callPackage ./pkgs/mc-rtc/controllers/panda-prosthesis {};
+
+    ###########
+    # PLUGINS #
+    ###########
+    mc-force-shoe-plugin = callWithLocal ./pkgs/mc-rtc/plugins/mc-force-shoe-plugin.nix { };
+    mc-robot-model-update = callWithLocal ./pkgs/mc-rtc/plugins/mc-robot-model-update.nix { };
+
+    #############
+    # 3rd-party #
+    #############
+    eigen-fmt = prev.callPackage ./pkgs/3rd-party/eigen-fmt {
+      fmt = prev.fmt_10;
+    };
+    politopix = prev.callPackage ./pkgs/3rd-party/politopix.nix {
+      fetchurl = final.stdenv.fetchurlBoot;
+    };
+
+    imguizmo = callWithLocal ./pkgs/3rd-party/imguizmo.nix {
+      jrl-cmakemodules = final.jrl-cmakemodulesv2;
+    };
+    corrade = prev.callPackage ./pkgs/3rd-party/magnum/corrade.nix { };
+    magnum = prev.callPackage ./pkgs/3rd-party/magnum/magnum.nix { };
+    magnum-integration = callWithLocal ./pkgs/3rd-party/magnum/magnum-integration.nix {
+      with-imguiintegration = true;
+    };
+    magnum-plugins = callWithLocal ./pkgs/3rd-party/magnum/magnum-plugins.nix {
+      magnumPluginsWithAssimpImporter = true;
+      magnumPluginsWithStbImageImporter = true;
+    };
+    magnum-with-plugins = prev.callPackage ./pkgs/3rd-party/magnum/magnum-with-plugins.nix { };
+    mc-rtc-imgui = callWithLocal ./pkgs/mc-rtc-imgui {
+      jrl-cmakemodules = final.jrl-cmakemodulesv2;
+    };
+    # standlone version of mc-rtc-magnum, with independent packaging for magnum and its plugins
+    # and a standalone mc-rtc-imgui version
+    mc-rtc-magnum = prev.callPackage ./pkgs/mc-rtc-magnum/standalone.nix { };
+
+    #####################
+    # mc-rtc-superbuild #
+    #####################
+    # This derivation provides a mechanism to bring configurations of the whole framework together,
+    # that is:
+    # - mc-rtc itself
+    # - all runtime dependencies controllers/robots/observers/plugins required by the user
+    # - a default mc-rtc configuration, e.g which controller/timestep/main robot to use, or if the controllers
+    #   provide a suitable mc_rtc.yaml file, it can be referenced here as well
+    #
+    # This is handled as follows:
+    # - all runtime dependencies (including mc-rtc) are built independently, and their output is merged together (symlinkJoin) into a single runtimepath
+    # - the default mc_rtc.yaml runtime paths are overridden with corresponding paths in the merged output such that all runtime dependencies are available at the same place (this avoids confusion as to where each runtime dependency is located in the store and makes for a more user-friendly approach). In practice mc_rtc loads this mc_rtc.yaml override through the MC_RTC_CONTROLLER_CONFIG environment variable
+    #
+    # Note that local out-of-nix overrides from local source folders of controller/robot/plugin/observers can be achieved by:
+    # - prefixing LD_LIBRARY_PATH with the local intalled lib path
+    # - providing a custom mc_rtc.yaml with ControllerModulePaths, ObserverModulePaths, etc pointing to their corresponding installed folder
+    # This is not per-say recomended, but it can drastically reduce build time for these components, and also allow for seamless LSP integration in your editor.
+    #
+    # TODO: investigate use of ccacheStdenv
+    # mc-rtc-superbuild = prev.callPackage ./pkgs/mc-rtc/mc-rtc-superbuild-symlinkjoin.nix.nix {
+
+    # minimal superbuild environment (jvrc1, mc_rtc_ticker)
+    mc-rtc-superbuild-minimal = prev.callPackage ./pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix {
+      superbuildArgs = {
+        pname = "mc-rtc-superbuild-minimal";
+      };
+    };
+
+    # default superbuild environment (jvrc1 robot, with gui apps and mujoco simulation)
+    mc-rtc-superbuild = prev.callPackage ./pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix {
+      superbuildArgs = final.mc-rtc-superbuild-minimal.superbuildArgs // {
+        pname = "mc-rtc-superbuild";
+        apps = [
+          final.mc-rtc-magnum
+          final.mc-mujoco
+          final.mc-rtc-ticker
+        ];
+      };
+    };
+
+    # default superbuild environment with all public robots (jvrc1, g1, h1, ur5e), with gui apps
+    mc-rtc-superbuild-all-public-robots =
+      prev.callPackage ./pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix
+        {
+          superbuildArgs = final.mc-rtc-superbuild.superbuildArgs // {
+            pname = "mc-rtc-superbuild-all-public-robots";
+            robots = final.mc-rtc-superbuild.superbuildArgs.robots ++ [
+              final.mc-g1
+              final.mc-h1
+              final.mc-ur5e
+            ];
+          };
+        };
+
+    # full superbuild environment (all public robots, all default controllers, gui apps, mujoco)
+    mc-rtc-superbuild-full = prev.callPackage ./pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix {
+      superbuildArgs = final.mc-rtc-superbuild-all-public-robots.superbuildArgs // {
+        pname = "mc-rtc-superbuild-full";
+      };
+    };
+
+    # TODO: move to rolkneematic's panda_prosthesis repository
+    # mc-rtc-superbuild-rolkneematics = prev.callPackage ./pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix {
+    #   superbuildArgs = final.mc-rtc-superbuild.superbuildArgs // {
+    #     pname = "mc-rtc-superbuild-rolkneematics";
+    #     robots = [
+    #       # note that panda-prosthesis is not strictly-speaking a robot, but it builds a robot module so we need it here as well to populate the robots runtime paths
+    #       final.panda-prosthesis
+    #       final.mc-panda-lirmm
+    #       final.mc-panda
+    #     ];
+    #     controllers = [ final.panda-prosthesis ];
+    #     # extra mc_rtc.yaml
+    #     configs = [ "${final.panda-prosthesis}/lib/mc_controller/etc/mc_rtc.yaml" ];
+    #     observers = [ ];
+    #     plugins = [ final.panda-prosthesis ];
+    #     apps = [
+    #       final.mc-rtc-magnum
+    #       final.mc-franka
+    #       final.mc-rtc-ticker
+    #     ];
+    # };
+  }
+)

--- a/overlay.nix
+++ b/overlay.nix
@@ -315,27 +315,5 @@
         pname = "mc-rtc-superbuild-full";
       };
     };
-
-    # TODO: move to rolkneematic's panda_prosthesis repository
-    # mc-rtc-superbuild-rolkneematics = prev.callPackage ./pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix {
-    #   superbuildArgs = final.mc-rtc-superbuild.superbuildArgs // {
-    #     pname = "mc-rtc-superbuild-rolkneematics";
-    #     robots = [
-    #       # note that panda-prosthesis is not strictly-speaking a robot, but it builds a robot module so we need it here as well to populate the robots runtime paths
-    #       final.panda-prosthesis
-    #       final.mc-panda-lirmm
-    #       final.mc-panda
-    #     ];
-    #     controllers = [ final.panda-prosthesis ];
-    #     # extra mc_rtc.yaml
-    #     configs = [ "${final.panda-prosthesis}/lib/mc_controller/etc/mc_rtc.yaml" ];
-    #     observers = [ ];
-    #     plugins = [ final.panda-prosthesis ];
-    #     apps = [
-    #       final.mc-rtc-magnum
-    #       final.mc-franka
-    #       final.mc-rtc-ticker
-    #     ];
-    # };
   }
 )

--- a/pkgs/3rd-party/eigen-fmt/default.nix
+++ b/pkgs/3rd-party/eigen-fmt/default.nix
@@ -1,19 +1,27 @@
-{ stdenv, lib, fetchgit, cmake,
-eigen, fmt,
-useLocal ? false, localWorkspace ? null
+{
+  stdenv,
+  lib,
+  fetchgit,
+  cmake,
+  eigen,
+  fmt,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
 # eigen-fmt derivation, avoiding the use of PID build system
-stdenv.mkDerivation (finalAttrs:{
+stdenv.mkDerivation (finalAttrs: {
   pname = "eigen-fmt";
   version = "1.0.4";
 
-  src = if useLocal then
-      builtins.trace "Using local workspace for eigen-fmt: ${localWorkspace}/eigen-fmt"
-      (builtins.path {
-        path = "${localWorkspace}/${finalAttrs.pname}";
-        name = "${finalAttrs.pname}-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for eigen-fmt: ${localWorkspace}/eigen-fmt" (
+        builtins.path {
+          path = "${localWorkspace}/${finalAttrs.pname}";
+          name = "${finalAttrs.pname}-src";
+        }
+      )
     else
       # fetchgit {
       #   url = "https://gite.lirmm.fr/rpc/utils/eigen-fmt.git";
@@ -35,14 +43,17 @@ stdenv.mkDerivation (finalAttrs:{
   '';
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ eigen fmt ];
+  propagatedBuildInputs = [
+    eigen
+    fmt
+  ];
 
   doCheck = false;
 
   meta = with lib; {
     description = "Provides custom formatters for eigen types to be used with the {fmt} library";
-    homepage    = "https://gite.lirmm.fr/rpc/utils/eigen-fmt";
-    license     = licenses.cecill21;
-    platforms   = platforms.all;
+    homepage = "https://gite.lirmm.fr/rpc/utils/eigen-fmt";
+    license = licenses.cecill21;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/3rd-party/imguizmo.nix
+++ b/pkgs/3rd-party/imguizmo.nix
@@ -1,5 +1,8 @@
 # filepath: pkgs/3rd-party/imguizmo/imguizmo.nix
-{ stdenv, lib, fetchgit,
+{
+  stdenv,
+  lib,
+  fetchgit,
   cmake,
   imgui,
   jrl-cmakemodules,
@@ -7,18 +10,20 @@
   localWorkspace ? null,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (_finalAttrs: {
   pname = "imguizmo";
   version = "0.0.0";
 
   dontBuild = true;
 
-  src = if useLocal then
-    builtins.trace "Using local workspace for imguizmo: ${localWorkspace}/ImGuizmo"
-      (builtins.path {
-        path = "${localWorkspace}/ImGuizmo";
-        name = "imguizmo-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for imguizmo: ${localWorkspace}/ImGuizmo" (
+        builtins.path {
+          path = "${localWorkspace}/ImGuizmo";
+          name = "imguizmo-src";
+        }
+      )
     else
       # fetchFromGitHub {
       #   owner = "CedricGuillemet";
@@ -32,19 +37,22 @@ stdenv.mkDerivation (finalAttrs: {
         hash = "sha256-JLwciNGo90vR5tsFB4z5JPvhCz38FhN9Ja/5+Ct6YPo=";
       };
 
-  nativeBuildInputs = [ cmake jrl-cmakemodules ];
+  nativeBuildInputs = [
+    cmake
+    jrl-cmakemodules
+  ];
   propagatedBuildInputs = [
     imgui
   ];
 
-  cmakeFlags = [];
+  cmakeFlags = [ ];
 
   doCheck = false;
 
   meta = with lib; {
     description = "Immediate mode 3D gizmo for scene editing and other controls based on Dear Imgui ";
-    homepage    = "https://github.com/CedricGuillemet/imguizmo";
-    license     = licenses.mit;
-    platforms   = platforms.all;
+    homepage = "https://github.com/CedricGuillemet/imguizmo";
+    license = licenses.mit;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/3rd-party/magnum/corrade.nix
+++ b/pkgs/3rd-party/magnum/corrade.nix
@@ -1,20 +1,26 @@
-{ stdenv, lib, fetchFromGitHub,
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
   cmake,
-  useLocal ? false, localWorkspace ? null
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (_finalAttrs: {
   pname = "corrade";
   version = "0.0.0";
 
   dontBuild = true;
 
-  src = if useLocal then
-      builtins.trace "Using local workspace for magnum: ${localWorkspace}/corrade"
-      (builtins.path {
-        path = "${localWorkspace}/corrade";
-        name = "magnum-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for magnum: ${localWorkspace}/corrade" (
+        builtins.path {
+          path = "${localWorkspace}/corrade";
+          name = "magnum-src";
+        }
+      )
     else
       fetchFromGitHub {
         owner = "mosra";
@@ -25,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
       };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [];
+  propagatedBuildInputs = [ ];
 
   cmakeFlags = [
   ];
@@ -34,8 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "C++11 multiplatform utility library ";
-    homepage    = "https://github.com/msora/corrade";
-    license     = licenses.bsd2; # FIXME
-    platforms   = platforms.all;
+    homepage = "https://github.com/msora/corrade";
+    license = licenses.bsd2; # FIXME
+    platforms = platforms.all;
   };
 })

--- a/pkgs/3rd-party/magnum/magnum-integration.nix
+++ b/pkgs/3rd-party/magnum/magnum-integration.nix
@@ -1,15 +1,13 @@
-{ stdenv, lib, fetchFromGitHub,
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
   cmake,
   magnum,
   imgui,
-  useLocal ? false, localWorkspace ? null,
-  with-bulletintegration ? false,
-  with-dartintegration ? false,
-  with-eigenintegration ? false,
-  with-glmintegration ? false,
+  useLocal ? false,
+  localWorkspace ? null,
   with-imguiintegration ? false,
-  with-ovrintegration ? false,
-  with-yogaintegration ? false
 }:
 
 # option(MAGNUM_WITH_BULLETINTEGRATION "Build BulletIntegration library" OFF)
@@ -20,18 +18,21 @@
 # option(MAGNUM_WITH_OVRINTEGRATION "Build OvrIntegration library" OFF)
 # option(MAGNUM_WITH_YOGAINTEGRATION "Build YogaIntegration library" OFF)
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (_finalAttrs: {
   pname = "magnum-integration";
   version = "0.0.0";
 
   dontBuild = true;
 
-  src = if useLocal then
+  src =
+    if useLocal then
       builtins.trace "Using local workspace for magnum-integration: ${localWorkspace}/magnum-integration"
-      (builtins.path {
-        path = "${localWorkspace}/magnum-integration";
-        name = "magnum-integration-src";
-      })
+        (
+          builtins.path {
+            path = "${localWorkspace}/magnum-integration";
+            name = "magnum-integration-src";
+          }
+        )
     else
       fetchFromGitHub {
         owner = "mosra";
@@ -41,21 +42,16 @@ stdenv.mkDerivation (finalAttrs: {
       };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = 
-    [ magnum ]
-    ++ lib.optional with-imguiintegration imgui
-    ;
+  propagatedBuildInputs = [ magnum ] ++ lib.optional with-imguiintegration imgui;
 
-  cmakeFlags = []
-  ++ lib.optional with-imguiintegration "-DMAGNUM_WITH_IMGUIINTEGRATION=ON"
-  ;
+  cmakeFlags = [ ] ++ lib.optional with-imguiintegration "-DMAGNUM_WITH_IMGUIINTEGRATION=ON";
 
   doCheck = false;
 
   meta = with lib; {
     description = "Integration libraries for the Magnum C++11 graphics engine";
-    homepage    = "https://github.com/msora/magnum-integration";
-    license     = licenses.bsd2; # FIXME
-    platforms   = platforms.all;
+    homepage = "https://github.com/msora/magnum-integration";
+    license = licenses.bsd2; # FIXME
+    platforms = platforms.all;
   };
 })

--- a/pkgs/3rd-party/magnum/magnum-plugins.nix
+++ b/pkgs/3rd-party/magnum/magnum-plugins.nix
@@ -1,4 +1,7 @@
-{ stdenv, lib, fetchFromGitHub,
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
   cmake,
   magnum,
   useLocal ? false,
@@ -34,21 +37,23 @@
   magnumPluginsWithStbImageConverter ? false,
   magnumPluginsWithStbVorbisAudioImporter ? false,
   magnumPluginsWithTinyGltfImporter ? false,
-  magnumPluginsWithUvImageConverter ? false
+  magnumPluginsWithUvImageConverter ? false,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (_finalAttrs: {
   pname = "magnum-plugins";
   version = "0.0.0";
 
   dontBuild = true;
 
-  src = if useLocal then
-    builtins.trace "Using local workspace for magnum-plugins: ${localWorkspace}/magnum-plugins"
-      (builtins.path {
-        path = "${localWorkspace}/magnum-plugins";
-        name = "magnum-plugins-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for magnum-plugins: ${localWorkspace}/magnum-plugins" (
+        builtins.path {
+          path = "${localWorkspace}/magnum-plugins";
+          name = "magnum-plugins-src";
+        }
+      )
     else
       fetchFromGitHub {
         owner = "mosra";
@@ -61,8 +66,10 @@ stdenv.mkDerivation (finalAttrs: {
   propagatedBuildInputs = [
     magnum
   ]
-  ++ lib.optionals magnumPluginsWithAssimpImporter [ assimp libz ]
-  ;
+  ++ lib.optionals magnumPluginsWithAssimpImporter [
+    assimp
+    libz
+  ];
 
   cmakeFlags = [
     "-DMAGNUM_WITH_ASSIMPIMPORTER=${if magnumPluginsWithAssimpImporter then "ON" else "OFF"}"
@@ -81,7 +88,9 @@ stdenv.mkDerivation (finalAttrs: {
     "-DMAGNUM_WITH_KTXIMAGECONVERTER=${if magnumPluginsWithKtxImageConverter then "ON" else "OFF"}"
     "-DMAGNUM_WITH_KTXIMPORTER=${if magnumPluginsWithKtxImporter then "ON" else "OFF"}"
     "-DMAGNUM_WITH_MESHOPTIMIZER=${if magnumPluginsWithMeshOptimizer then "ON" else "OFF"}"
-    "-DMAGNUM_WITH_MINIEXRIMAGECONVERTER=${if magnumPluginsWithMiniExrImageConverter then "ON" else "OFF"}"
+    "-DMAGNUM_WITH_MINIEXRIMAGECONVERTER=${
+      if magnumPluginsWithMiniExrImageConverter then "ON" else "OFF"
+    }"
     "-DMAGNUM_WITH_OPENDDL=${if magnumPluginsWithOpenDdl then "ON" else "OFF"}"
     "-DMAGNUM_WITH_OPENGEXIMPORTER=${if magnumPluginsWithOpenGexImporter then "ON" else "OFF"}"
     "-DMAGNUM_WITH_PNGIMAGECONVERTER=${if magnumPluginsWithPngImageConverter then "ON" else "OFF"}"
@@ -90,7 +99,9 @@ stdenv.mkDerivation (finalAttrs: {
     "-DMAGNUM_WITH_STANFORDIMPORTER=${if magnumPluginsWithStanfordImporter then "ON" else "OFF"}"
     "-DMAGNUM_WITH_STBIMAGECONVERTER=${if magnumPluginsWithStbImageConverter then "ON" else "OFF"}"
     "-DMAGNUM_WITH_STBIMAGEIMPORTER=${if magnumPluginsWithStbImageImporter then "ON" else "OFF"}"
-    "-DMAGNUM_WITH_STBVORBISAUDIOIMPORTER=${if magnumPluginsWithStbVorbisAudioImporter then "ON" else "OFF"}"
+    "-DMAGNUM_WITH_STBVORBISAUDIOIMPORTER=${
+      if magnumPluginsWithStbVorbisAudioImporter then "ON" else "OFF"
+    }"
     "-DMAGNUM_WITH_TINYGLTFIMPORTER=${if magnumPluginsWithTinyGltfImporter then "ON" else "OFF"}"
     "-DMAGNUM_WITH_UVIMAGECONVERTER=${if magnumPluginsWithUvImageConverter then "ON" else "OFF"}"
   ];
@@ -99,8 +110,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Plugins for the Magnum C++11 graphics engine";
-    homepage    = "https://github.com/msora/magnum-plugins";
-    license     = licenses.bsd2; # FIXME
-    platforms   = platforms.all;
+    homepage = "https://github.com/msora/magnum-plugins";
+    license = licenses.bsd2; # FIXME
+    platforms = platforms.all;
   };
 })

--- a/pkgs/3rd-party/magnum/magnum-with-plugins.nix
+++ b/pkgs/3rd-party/magnum/magnum-with-plugins.nix
@@ -1,8 +1,17 @@
-{ stdenv, symlinkJoin, magnum, magnum-integration, magnum-plugins }:
+{
+  symlinkJoin,
+  magnum,
+  magnum-integration,
+  magnum-plugins,
+}:
 
 symlinkJoin {
   name = "magnum-with-plugins";
-  paths = [ magnum magnum-integration magnum-plugins ];
+  paths = [
+    magnum
+    magnum-integration
+    magnum-plugins
+  ];
   meta = magnum.meta // {
     description = "Magnum with all selected plugins, libraries symlinked together (using symlinkJoin)";
   };

--- a/pkgs/3rd-party/magnum/magnum.nix
+++ b/pkgs/3rd-party/magnum/magnum.nix
@@ -1,5 +1,8 @@
 # filepath: pkgs/3rd-party/magnum/magnum.nix
-{ stdenv, lib, fetchFromGitHub,
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
   cmake,
   corrade,
   libGL,
@@ -15,21 +18,23 @@
   magnumWithAnySceneImporter ? true,
   magnumWithObjImporter ? true,
   magnumWithAssimpImporter ? true,
-  magnumWithStbImageImporter ? false
+  magnumWithStbImageImporter ? false,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (_finalAttrs: {
   pname = "magnum";
   version = "0.0.0";
 
   dontBuild = true;
 
-  src = if useLocal then
-    builtins.trace "Using local workspace for magnum: ${localWorkspace}/magnum"
-      (builtins.path {
-        path = "${localWorkspace}/magnum-standalone";
-        name = "magnum-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for magnum: ${localWorkspace}/magnum" (
+        builtins.path {
+          path = "${localWorkspace}/magnum-standalone";
+          name = "magnum-src";
+        }
+      )
     else
       fetchFromGitHub {
         owner = "mosra";
@@ -67,8 +72,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Lightweight and modular C++11 graphics middleware for games and data visualization ";
-    homepage    = "https://github.com/msora/magnum";
-    license     = licenses.bsd2; # FIXME
-    platforms   = platforms.all;
+    homepage = "https://github.com/msora/magnum";
+    license = licenses.bsd2; # FIXME
+    platforms = platforms.all;
   };
 })

--- a/pkgs/3rd-party/politopix.nix
+++ b/pkgs/3rd-party/politopix.nix
@@ -1,18 +1,25 @@
-{ stdenv, lib, fetchurl, fetchFromGitHub,
-cmake, boost,
-useLocal ? false, localWorkspace ? null
+{
+  stdenv,
+  lib,
+  fetchurl,
+  cmake,
+  boost,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "politopix";
   version = "1.0.0";
 
-  src = if useLocal then
-      builtins.trace "Using local workspace for politopix: ${localWorkspace}/politopix"
-      (builtins.path {
-        path = "${localWorkspace}/politopix";
-        name = "politopix-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for politopix: ${localWorkspace}/politopix" (
+        builtins.path {
+          path = "${localWorkspace}/politopix";
+          name = "politopix-src";
+        }
+      )
     else
       # fetchFromGitHub {
       #   owner = "Hugo-L3174";
@@ -46,8 +53,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = " Github port of I2S Bordeaux's politopix library ";
-    homepage    = "https://github.com/Hugo-L3174/politopix";
-    license     = lib.licenses.gpl3Plus;
-    platforms   = platforms.all;
+    homepage = "https://github.com/Hugo-L3174/politopix";
+    license = lib.licenses.gpl3Plus;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/copra/default.nix
+++ b/pkgs/copra/default.nix
@@ -1,5 +1,12 @@
-
-{ stdenv, lib, fetchurl, cmake, boost, eigen-qld, eigen-quadprog }:
+{
+  stdenv,
+  lib,
+  fetchurl,
+  cmake,
+  boost,
+  eigen-qld,
+  eigen-quadprog,
+}:
 
 stdenv.mkDerivation {
   pname = "copra";
@@ -11,7 +18,11 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ boost eigen-qld eigen-quadprog ];
+  propagatedBuildInputs = [
+    boost
+    eigen-qld
+    eigen-quadprog
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -23,8 +34,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Copra (Control & preview algorithms) is a C++ library implementing linear model predictive control. It relies on quadratic programming (QP) solvers.";
-    homepage    = "https://github.com/jrl-umi3218/copra";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/copra";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/eigen-qld/default.nix
+++ b/pkgs/eigen-qld/default.nix
@@ -1,4 +1,11 @@
-{ stdenv, lib, fetchurl, cmake, gfortran, eigen }:
+{
+  stdenv,
+  lib,
+  fetchurl,
+  cmake,
+  gfortran,
+  eigen,
+}:
 
 stdenv.mkDerivation rec {
   pname = "eigen-qld";
@@ -9,7 +16,10 @@ stdenv.mkDerivation rec {
     sha256 = "835fca05e2274b7ae9dbe250db5f28b193e28318d55e10d354cf8d443c10fcaf";
   };
 
-  nativeBuildInputs = [ cmake gfortran ];
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ];
   propagatedBuildInputs = [ eigen ];
 
   cmakeFlags = [
@@ -22,8 +32,8 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "eigen-qld allow to use the QLD QP solver with the Eigen3 library";
-    homepage    = "https://github.com/jrl-umi3218/eigen-qld";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/eigen-qld";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/eigen-quadprog/default.nix
+++ b/pkgs/eigen-quadprog/default.nix
@@ -1,4 +1,11 @@
-{ stdenv, lib, fetchurl, cmake, gfortran, eigen }:
+{
+  stdenv,
+  lib,
+  fetchurl,
+  cmake,
+  gfortran,
+  eigen,
+}:
 
 stdenv.mkDerivation rec {
   pname = "eigen-quadprog";
@@ -9,7 +16,10 @@ stdenv.mkDerivation rec {
     sha256 = "68f34c237daaa9bd6abce8fcc2a3a53e459332eefb2c22e05529293f00a53a2f";
   };
 
-  nativeBuildInputs = [ cmake gfortran ];
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ];
   propagatedBuildInputs = [ eigen ];
 
   cmakeFlags = [
@@ -22,8 +32,8 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "eigen-quadprog allow to use the quadprog QP solver with the Eigen3 library";
-    homepage    = "https://github.com/jrl-umi3218/eigen-quadprog";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/eigen-quadprog";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/gram-savitzky-golay/default.nix
+++ b/pkgs/gram-savitzky-golay/default.nix
@@ -1,18 +1,28 @@
-{ stdenv, lib, fetchgit,
-cmake, eigen, boost,
-useLocal ? false, localWorkspace ? null
+{
+  stdenv,
+  lib,
+  fetchgit,
+  cmake,
+  eigen,
+  boost,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (_finalAttrs: {
   pname = "gram-savitzky-golay";
   version = "1.0.1";
 
-  src = if useLocal then
-      builtins.trace "Using local workspace for gram-savitzky-golay: ${localWorkspace}/gram_savitzky_golay"
-      (builtins.path {
-        path = "${localWorkspace}/gram_savitzky_golay";
-        name = "gram-savitzky-golay-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace
+        "Using local workspace for gram-savitzky-golay: ${localWorkspace}/gram_savitzky_golay"
+        (
+          builtins.path {
+            path = "${localWorkspace}/gram_savitzky_golay";
+            name = "gram-savitzky-golay-src";
+          }
+        )
     else
       fetchgit {
         url = "https://github.com/jrl-umi3218/gram_savitzky_golay.git";
@@ -23,19 +33,19 @@ stdenv.mkDerivation (finalAttrs: {
       };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs =
-    [
-      eigen boost
-    ];
+  propagatedBuildInputs = [
+    eigen
+    boost
+  ];
 
-  cmakeFlags = [];
+  cmakeFlags = [ ];
 
   doCheck = false;
 
   meta = with lib; {
     description = "C++ Implementation of Savitzky-Golay filtering based on Gram polynomials";
-    homepage    = "https://github.com/jrl-umi3218/gram_savitzky_golay";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/gram_savitzky_golay";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/mc-rbdyn-urdf/default.nix
+++ b/pkgs/mc-rbdyn-urdf/default.nix
@@ -1,4 +1,11 @@
-{ stdenv, lib, fetchurl, cmake, rbdyn, boost }:
+{
+  stdenv,
+  lib,
+  fetchurl,
+  cmake,
+  rbdyn,
+  boost,
+}:
 
 stdenv.mkDerivation {
   pname = "mc-rbdyn-urdf";
@@ -10,7 +17,10 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ rbdyn boost ];
+  propagatedBuildInputs = [
+    rbdyn
+    boost
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -22,8 +32,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "mc-rbdyn-urdf allows one to parse an URDF file and create RBDyn structure from it";
-    homepage    = "https://github.com/jrl-umi3218/mc_rbdyn_urdf";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/mc_rbdyn_urdf";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc-data/default.nix
+++ b/pkgs/mc-rtc-data/default.nix
@@ -1,13 +1,14 @@
-{ stdenv
-, lib
-, with-ros ? false
-, buildRosPackage
-, ament-cmake
-, mc-env-description
-, mc-int-obj-description
-, jvrc-description
-, writeTextFile
-, runCommand
+{
+  stdenv,
+  lib,
+  with-ros ? false,
+  buildRosPackage,
+  ament-cmake,
+  mc-env-description,
+  mc-int-obj-description,
+  jvrc-description,
+  writeTextFile,
+  runCommand,
 }:
 
 let
@@ -15,9 +16,18 @@ let
   pname = "mc-rtc-data";
 
   deps = [
-    { name = "mc_env_description"; drv = mc-env-description; }
-    { name = "mc_int_obj_description"; drv = mc-int-obj-description; }
-    { name = "jvrc_description"; drv = jvrc-description; }
+    {
+      name = "mc_env_description";
+      drv = mc-env-description;
+    }
+    {
+      name = "mc_int_obj_description";
+      drv = mc-int-obj-description;
+    }
+    {
+      name = "jvrc_description";
+      drv = jvrc-description;
+    }
   ];
 
   execDependsXml = lib.concatMapStrings (d: "<exec_depend>${d.name}</exec_depend>\n") deps;
@@ -69,9 +79,9 @@ if with-ros then
     nativeBuildInputs = [ ament-cmake ];
     meta = with lib; {
       description = "Metapackage for mc-rtc data (envs, objects, etc)";
-      homepage    = "https://github.com/jrl-umi3218/mc_rtc_data";
-      license     = licenses.bsd2;
-      platforms   = platforms.all;
+      homepage = "https://github.com/jrl-umi3218/mc_rtc_data";
+      license = licenses.bsd2;
+      platforms = platforms.all;
     };
   }
 else
@@ -79,15 +89,15 @@ else
     inherit pname version;
     src = null;
     propagatedBuildInputs = map (d: d.drv) deps;
-    buildInputs = [];
+    buildInputs = [ ];
     nativeBuildInputs = [ ];
     installPhase = ''
       mkdir -p $out
     '';
     meta = with lib; {
       description = "Metapackage for mc-rtc data (envs, objects, etc)";
-      homepage    = "https://github.com/jrl-umi3218/mc_rtc_data";
-      license     = licenses.bsd2;
-      platforms   = platforms.all;
+      homepage = "https://github.com/jrl-umi3218/mc_rtc_data";
+      license = licenses.bsd2;
+      platforms = platforms.all;
     };
   }

--- a/pkgs/mc-rtc-data/jvrc-description.nix
+++ b/pkgs/mc-rtc-data/jvrc-description.nix
@@ -1,6 +1,14 @@
-{ stdenv, lib, fetchgit, cmake, ament-cmake,
-with-ros ? false, buildRosPackage,
-useLocal ? false, localWorkspace ? null }:
+{
+  stdenv,
+  lib,
+  fetchgit,
+  cmake,
+  ament-cmake,
+  with-ros ? false,
+  buildRosPackage,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 let
   version = "1.0.8";
@@ -10,20 +18,23 @@ in
   pname = "${pname}";
   version = "${version}";
 
-  src = if useLocal then
-        builtins.trace "Using local workspace for ${pname}: ${localWorkspace}/jvrc_description"
-        (builtins.path {
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for ${pname}: ${localWorkspace}/jvrc_description" (
+        builtins.path {
           path = "${localWorkspace}/jvrc_description";
           name = "${pname}-src";
-        })
-      else
-        # TODO: release
-        fetchgit { # master
-          url = "https://github.com/jrl-umi3218/jvrc_description";
-          rev = "80a2aacca2dc1e3aa3d590bbe991a4ef14d54e56";
-          sha256 = "sha256-/CNO8GTDVUkrj8VsezEGEMGodwQISgIa1XVhfiziy5w=";
-          fetchSubmodules = true;
-        };
+        }
+      )
+    else
+      # TODO: release
+      fetchgit {
+        # master
+        url = "https://github.com/jrl-umi3218/jvrc_description";
+        rev = "80a2aacca2dc1e3aa3d590bbe991a4ef14d54e56";
+        sha256 = "sha256-/CNO8GTDVUkrj8VsezEGEMGodwQISgIa1XVhfiziy5w=";
+        fetchSubmodules = true;
+      };
 
   buildType = "ament_cmake";
   nativeBuildInputs = if with-ros then [ ament-cmake ] else [ cmake ];
@@ -39,8 +50,8 @@ in
 
   meta = with lib; {
     description = "Data for mc_rtc";
-    homepage    = "https://github.com/jrl-umi3218/mc_env_description";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/mc_env_description";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc-data/mc-env-description.nix
+++ b/pkgs/mc-rtc-data/mc-env-description.nix
@@ -1,6 +1,14 @@
-{ stdenv, lib, fetchgit, cmake, ament-cmake,
-with-ros ? false, buildRosPackage,
-useLocal ? false, localWorkspace ? null }:
+{
+  stdenv,
+  lib,
+  fetchgit,
+  cmake,
+  ament-cmake,
+  with-ros ? false,
+  buildRosPackage,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 let
   version = "1.0.8";
@@ -14,22 +22,23 @@ in
   src =
     if useLocal then
       builtins.trace "Using local workspace for mc-env-description: ${localWorkspace}/mc_env_description"
-      (builtins.path {
-        path = "${localWorkspace}/mc_env_description";
-        name = "${pname}-src";
+        (
+          builtins.path {
+            path = "${localWorkspace}/mc_env_description";
+            name = "${pname}-src";
+          }
+        )
+    else if with-ros then
+      builtins.trace "with-ros true: ${toString with-ros}" (fetchgit {
+        # master
+        url = "https://github.com/jrl-umi3218/mc_env_description";
+        rev = "b55cddfead7a43217d5b179a6eca213ad94f4e65";
+        sha256 = "sha256-5sjyojlG+MM4OCUmNSlEhu7FLvckk2n7oE8mFu9H7Sw=";
+        fetchSubmodules = true;
       })
-    else 
-      if with-ros then
-        builtins.trace "with-ros true: ${toString with-ros}"
-        (fetchgit { # master
-          url = "https://github.com/jrl-umi3218/mc_env_description";
-          rev = "b55cddfead7a43217d5b179a6eca213ad94f4e65";
-          sha256 = "sha256-5sjyojlG+MM4OCUmNSlEhu7FLvckk2n7oE8mFu9H7Sw=";
-          fetchSubmodules = true;
-        })
     else
-      builtins.trace "with-ros false: ${toString with-ros}"
-      (fetchgit { # master
+      builtins.trace "with-ros false: ${toString with-ros}" (fetchgit {
+        # master
         url = "https://github.com/jrl-umi3218/mc_env_description";
         rev = "ca84a40a0a27783c4ed63bd8f057af7ef41b33bb";
         sha256 = "sha256-ntz/u9YTWd2YuVhtRngm0qnOU8nsH0ODZ828x/Uba9s=";
@@ -54,8 +63,8 @@ in
 
   meta = with lib; {
     description = "Data for mc_rtc";
-    homepage    = "https://github.com/jrl-umi3218/mc_env_description";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/mc_env_description";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc-data/mc-int-obj-description.nix
+++ b/pkgs/mc-rtc-data/mc-int-obj-description.nix
@@ -1,7 +1,14 @@
-{ stdenv, lib, fetchgit, cmake,
-ament-cmake,
-with-ros ? false, buildRosPackage,
-useLocal ? false, localWorkspace ? null }:
+{
+  stdenv,
+  lib,
+  fetchgit,
+  cmake,
+  ament-cmake,
+  with-ros ? false,
+  buildRosPackage,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 let
   version = "1.0.8"; # TODO release
@@ -13,20 +20,23 @@ in
   version = "${version}";
   separateDebugInfo = false;
 
-  src = if useLocal then
-        builtins.trace "Using local workspace for mc-int-obj-description: ${srcPath}"
-        (builtins.path {
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for mc-int-obj-description: ${srcPath}" (
+        builtins.path {
           path = "${srcPath}";
           name = "${pname}-src";
-        })
-      else
-        # TODO: release
-        fetchgit { # master
-          url = "https://github.com/jrl-umi3218/mc_int_obj_description";
-          rev = "b5af6dc486ec9af3413399c815c0904635d6708a";
-          sha256 = "sha256-V/VxnReFTnJ5I9uJHwI1BQTDozqH2DEP01SQvkZs424=";
-          fetchSubmodules = true;
-        };
+        }
+      )
+    else
+      # TODO: release
+      fetchgit {
+        # master
+        url = "https://github.com/jrl-umi3218/mc_int_obj_description";
+        rev = "b5af6dc486ec9af3413399c815c0904635d6708a";
+        sha256 = "sha256-V/VxnReFTnJ5I9uJHwI1BQTDozqH2DEP01SQvkZs424=";
+        fetchSubmodules = true;
+      };
 
   buildType = "ament_cmake";
   nativeBuildInputs = if with-ros then [ ament-cmake ] else [ cmake ];
@@ -46,8 +56,8 @@ in
 
   meta = with lib; {
     description = "Data for mc_rtc";
-    homepage    = "https://github.com/jrl-umi3218/mc_int_obj_description";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/mc_int_obj_description";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc-imgui/default.nix
+++ b/pkgs/mc-rtc-imgui/default.nix
@@ -1,21 +1,30 @@
-{ stdenv, lib, fetchFromGitHub,
-cmake, jrl-cmakemodules,
-mc-rtc, imgui, implot
-, useLocal ? false, localWorkspace ? null
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  jrl-cmakemodules,
+  mc-rtc,
+  imgui,
+  implot,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (_finalAttrs: {
   pname = "mc-rtc-imgui";
   version = "1.0.0";
 
   dontBuild = true;
 
-  src = if useLocal then
-      builtins.trace "Using local workspace for mc-rtc-imgui: ${localWorkspace}/mc_rtc-imgui"
-      (builtins.path {
-        path = "${localWorkspace}/mc_rtc-imgui";
-        name = "mc-rtc-imgui-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for mc-rtc-imgui: ${localWorkspace}/mc_rtc-imgui" (
+        builtins.path {
+          path = "${localWorkspace}/mc_rtc-imgui";
+          name = "mc-rtc-imgui-src";
+        }
+      )
     else
       fetchFromGitHub {
         #owner = "mc-rtc";
@@ -28,13 +37,15 @@ stdenv.mkDerivation (finalAttrs: {
         hash = "sha256-J1oitwCXhtDGLW0vCnAN50BkUQeveuuruLz1TCOYe2Q=";
       };
 
-  nativeBuildInputs = [ cmake jrl-cmakemodules ];
-  propagatedBuildInputs =
-    [
-      mc-rtc
-      imgui
-      implot
-    ];
+  nativeBuildInputs = [
+    cmake
+    jrl-cmakemodules
+  ];
+  propagatedBuildInputs = [
+    mc-rtc
+    imgui
+    implot
+  ];
 
   cmakeFlags = [
     "-DMC_RTC_HONOR_INSTALL_PREFIX=ON"
@@ -44,8 +55,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Base GUI client for mc_rtc using Dear ImGui";
-    homepage    = "https://github.com/mc-rtc/mc_rtc-imgui";
-    license     = licenses.bsd2; # FIXME set licence in repository
-    platforms   = platforms.all;
+    homepage = "https://github.com/mc-rtc/mc_rtc-imgui";
+    license = licenses.bsd2; # FIXME set licence in repository
+    platforms = platforms.all;
   };
 })

--- a/pkgs/mc-rtc-magnum/default.nix
+++ b/pkgs/mc-rtc-magnum/default.nix
@@ -1,4 +1,14 @@
-{ stdenv, lib, fetchgit, cmake, mc-rtc, glfw, xorg, useLocal ? false, localWorkspace ? null }:
+{
+  stdenv,
+  lib,
+  fetchgit,
+  cmake,
+  mc-rtc,
+  glfw,
+  xorg,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 # TODO: modularize the build of mc_rtc-magnum instead of using submodules
 stdenv.mkDerivation {
@@ -13,23 +23,25 @@ stdenv.mkDerivation {
   #   sha256 = "sha256-6wwvyec7yfxjpa/njqsrw2k78kbsazy9+id+mp2je/8=";
   #   fetchsubmodules = true;
   # };
-  src = if useLocal then
-    builtins.trace "Using local workspace for mc_rtc-magnum: ${localWorkspace}/mc_rtc-magnum"
-    (builtins.path {
-      path = "${localWorkspace}/mc_rtc-magnum";
-      name = "mc_rtc-magnum-src";
-    })
-  else
-    fetchgit {
-      url = "https://github.com/mc-rtc/mc_rtc-magnum.git";
-      # topic/nix
-      rev = "6b9835904e4beb2c784214d8d96e1fc0eb596799";
-      sha256 = "sha256-xo8u7OEMNeNCevfH6Fj8t6dLSb7sDOftWhjqu8DwjyY=";
-      fetchSubmodules = true;
-    };
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for mc_rtc-magnum: ${localWorkspace}/mc_rtc-magnum" (
+        builtins.path {
+          path = "${localWorkspace}/mc_rtc-magnum";
+          name = "mc_rtc-magnum-src";
+        }
+      )
+    else
+      fetchgit {
+        url = "https://github.com/mc-rtc/mc_rtc-magnum.git";
+        # topic/nix
+        rev = "6b9835904e4beb2c784214d8d96e1fc0eb596799";
+        sha256 = "sha256-xo8u7OEMNeNCevfH6Fj8t6dLSb7sDOftWhjqu8DwjyY=";
+        fetchSubmodules = true;
+      };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ 
+  buildInputs = [
     mc-rtc
     glfw
     xorg.libX11
@@ -49,7 +61,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Magnum-based standalone viewer for mc-rtc";
     homepage = "https://github.com/mc-rtc/mc_rtc-magnum";
-    license     = licenses.bsd2;
+    license = licenses.bsd2;
     maintainers = [ ];
     platforms = platforms.all;
   };

--- a/pkgs/mc-rtc-magnum/standalone.nix
+++ b/pkgs/mc-rtc-magnum/standalone.nix
@@ -1,15 +1,15 @@
-{ stdenv, lib,
-makeWrapper,
-fetchgit,
-cmake,
-mc-rtc-imgui,
-corrade,
-magnum,
-magnum-integration,
-magnum-plugins,
-magnum-with-plugins,
-imguizmo,
-useLocal ? false, localWorkspace ? null }:
+{
+  stdenv,
+  lib,
+  makeWrapper,
+  fetchgit,
+  cmake,
+  mc-rtc-imgui,
+  magnum-with-plugins,
+  imguizmo,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 # TODO: modularize the build of mc_rtc-magnum instead of using submodules
 stdenv.mkDerivation {
@@ -24,29 +24,35 @@ stdenv.mkDerivation {
   #   sha256 = "sha256-6wwvyec7yfxjpa/njqsrw2k78kbsazy9+id+mp2je/8=";
   #   fetchsubmodules = true;
   # };
-  src = if useLocal then
-    builtins.trace "Using local workspace for mc_rtc-magnum: ${localWorkspace}/mc_rtc-magnum-standalone"
-    (builtins.path {
-      path = "${localWorkspace}/mc_rtc-magnum-standalone";
-      name = "mc_rtc-magnum-src";
-    })
-  else
-    fetchgit {
-      url = "https://github.com/mc-rtc/mc_rtc-magnum.git";
-      # NOTE
-      # topic/nix
-      # Use `nix` branch because it is hard to build against
-      # imgui/implot/imguizmo on non nix systems, and we need to keep
-      # supporting this: https://github.com/mc-rtc/mc_rtc-magnum/pull/4
-      # To be rebased on top of master on upgrade
-      rev = "97eb246eebda380b65b366e178a32107ad5a08d5";
-      sha256 = "sha256-Lek+JAQR6L2tgWXP1tsy077kVVh5roonuJqIDmWSNv4=";
-      fetchSubmodules = true;
-    };
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for mc_rtc-magnum: ${localWorkspace}/mc_rtc-magnum-standalone"
+        (
+          builtins.path {
+            path = "${localWorkspace}/mc_rtc-magnum-standalone";
+            name = "mc_rtc-magnum-src";
+          }
+        )
+    else
+      fetchgit {
+        url = "https://github.com/mc-rtc/mc_rtc-magnum.git";
+        # NOTE
+        # topic/nix
+        # Use `nix` branch because it is hard to build against
+        # imgui/implot/imguizmo on non nix systems, and we need to keep
+        # supporting this: https://github.com/mc-rtc/mc_rtc-magnum/pull/4
+        # To be rebased on top of master on upgrade
+        rev = "97eb246eebda380b65b366e178a32107ad5a08d5";
+        sha256 = "sha256-Lek+JAQR6L2tgWXP1tsy077kVVh5roonuJqIDmWSNv4=";
+        fetchSubmodules = true;
+      };
 
-  nativeBuildInputs = [ cmake makeWrapper ];
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+  ];
   dontBuild = true;
-  buildInputs = [ 
+  buildInputs = [
     mc-rtc-imgui
     # magnum
     # magnum-integration
@@ -73,7 +79,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Magnum-based standalone viewer for mc-rtc";
     homepage = "https://github.com/mc-rtc/mc_rtc-magnum";
-    license     = licenses.bsd2;
+    license = licenses.bsd2;
     maintainers = [ ];
     platforms = platforms.all;
   };

--- a/pkgs/mc-rtc-msgs/default.nix
+++ b/pkgs/mc-rtc-msgs/default.nix
@@ -1,6 +1,15 @@
-{ lib, buildRosPackage, fetchurl, colcon, rosidl-default-runtime, rosidl-default-generators,
-rosidl-typesupport-c, rosidl-typesupport-cpp, ament-cmake,
-geometry-msgs }:
+{
+  lib,
+  buildRosPackage,
+  fetchurl,
+  colcon,
+  rosidl-default-runtime,
+  rosidl-default-generators,
+  rosidl-typesupport-c,
+  rosidl-typesupport-cpp,
+  ament-cmake,
+  geometry-msgs,
+}:
 
 let
   version = "1.1.2";
@@ -16,11 +25,9 @@ buildRosPackage {
 
   buildType = "colcon";
 
-  buildInputs = 
-  [
+  buildInputs = [
   ];
-  propagatedBuildInputs = 
-  [
+  propagatedBuildInputs = [
     rosidl-default-generators
     geometry-msgs
     rosidl-default-runtime

--- a/pkgs/mc-rtc-raylib/default.nix
+++ b/pkgs/mc-rtc-raylib/default.nix
@@ -1,4 +1,18 @@
-{ stdenv, lib, fetchgit, cmake, mc-rtc, assimp, libGL, libXrandr, libXinerama, libXcursor, libX11, libXi, libXext }:
+{
+  stdenv,
+  lib,
+  fetchgit,
+  cmake,
+  mc-rtc,
+  assimp,
+  libGL,
+  libXrandr,
+  libXinerama,
+  libXcursor,
+  libX11,
+  libXi,
+  libXext,
+}:
 
 stdenv.mkDerivation {
   pname = "mc-rtc-raylib";
@@ -6,13 +20,23 @@ stdenv.mkDerivation {
 
   # master branch as of 2021.01.26
   src = fetchgit {
-      url = "https://github.com/gergondet/mc_rtc-raylib";
-      rev = "refs/heads/master";
-      sha256 = "sha256-FSJD1ZTiWekkQlVUmDwaXcCnNJQ9qbJg5LD/xybrZGc=";
-    };
+    url = "https://github.com/gergondet/mc_rtc-raylib";
+    rev = "refs/heads/master";
+    sha256 = "sha256-FSJD1ZTiWekkQlVUmDwaXcCnNJQ9qbJg5LD/xybrZGc=";
+  };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ mc-rtc assimp libGL libXrandr libXinerama libXcursor libX11 libXi libXext ];
+  propagatedBuildInputs = [
+    mc-rtc
+    assimp
+    libGL
+    libXrandr
+    libXinerama
+    libXcursor
+    libX11
+    libXi
+    libXext
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -24,8 +48,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "raylib based interface for mc-rtc";
-    homepage    = "https://github.com/gergondet/mc_rtc-raylib";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/gergondet/mc_rtc-raylib";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc/controllers/lipm-walking-controller/default.nix
+++ b/pkgs/mc-rtc/controllers/lipm-walking-controller/default.nix
@@ -1,5 +1,13 @@
-{ stdenv, lib, fetchgit, cmake, mc-rtc, copra,
-useLocal ? false, localWorkspace ? null }:
+{
+  stdenv,
+  lib,
+  fetchgit,
+  cmake,
+  mc-rtc,
+  copra,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 let
   version = "1.6.0";
@@ -13,19 +21,24 @@ stdenv.mkDerivation {
   src =
     if useLocal then
       builtins.trace "Using local workspace for lipm-walking-controller: ${localWorkspace}/${localFolder}"
-      (builtins.path {
-        path = "${localWorkspace}/${localFolder}";
-        name = "lipm-walking-controller-src";
-      })
+        (
+          builtins.path {
+            path = "${localWorkspace}/${localFolder}";
+            name = "lipm-walking-controller-src";
+          }
+        )
     else
       fetchgit {
-          url = "https://github.com/jrl-umi3218/lipm_walking_controller";
-          rev = "e28e9552faff0ee110fcc3d6ce11dc6bb4759e31";
-          sha256 = "sha256-nj1XWy9XHbk9oP1H2mZsFqmBJ1lnNG0CnMEA20VG6eQ";
-        };
+        url = "https://github.com/jrl-umi3218/lipm_walking_controller";
+        rev = "e28e9552faff0ee110fcc3d6ce11dc6bb4759e31";
+        sha256 = "sha256-nj1XWy9XHbk9oP1H2mZsFqmBJ1lnNG0CnMEA20VG6eQ";
+      };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ mc-rtc copra ];
+  propagatedBuildInputs = [
+    mc-rtc
+    copra
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -38,8 +51,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Walking controller based on linear inverted pendulum tracking";
-    homepage    = "https://github.com/jrl-umi3218/lipm_walking_controller";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/lipm_walking_controller";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc/controllers/panda-prosthesis/default.nix
+++ b/pkgs/mc-rtc/controllers/panda-prosthesis/default.nix
@@ -1,20 +1,32 @@
-{ stdenv, lib, fetchFromGitHub, fetchgit, 
-cmake, mc-rtc,
-socat, picocom, screen, minicom,
-mc-panda-lirmm,
-useLocal ? false, localWorkspace ? null
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  mc-rtc,
+  socat,
+  picocom,
+  screen,
+  minicom,
+  mc-panda-lirmm,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
 stdenv.mkDerivation {
   pname = "panda-prosthesis";
   version = "1.0.0";
 
-  src = if useLocal then
-      builtins.trace "Using local workspace for panda-prosthesis: ${localWorkspace}/panda_prosthesis_rolkneematics"
-      (builtins.path {
-        path = "${localWorkspace}/panda_prosthesis_rolkneematics";
-        name = "panda-prosthesis-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace
+        "Using local workspace for panda-prosthesis: ${localWorkspace}/panda_prosthesis_rolkneematics"
+        (
+          builtins.path {
+            path = "${localWorkspace}/panda_prosthesis_rolkneematics";
+            name = "panda-prosthesis-src";
+          }
+        )
     else
       # TODO: release panda-prosthesis
       # fetchgit {
@@ -32,11 +44,14 @@ stdenv.mkDerivation {
       };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs =
-    [
-      mc-rtc mc-panda-lirmm
-      socat picocom screen minicom # make serial communication debugging tools available
-    ];
+  propagatedBuildInputs = [
+    mc-rtc
+    mc-panda-lirmm
+    socat
+    picocom
+    screen
+    minicom # make serial communication debugging tools available
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -49,8 +64,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Panda RobotModule for mc-rtc";
-    homepage    = "https://github.com/jrl-umi3218/mc_panda";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/mc_panda";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc/controllers/polytopeController/dcm-vrptask.nix
+++ b/pkgs/mc-rtc/controllers/polytopeController/dcm-vrptask.nix
@@ -1,18 +1,28 @@
-{ stdenv, lib, fetchFromGitHub,
-cmake, mc-rtc, eigen-quadprog, gram-savitzky-golay, jrl-cmakemodules,
-useLocal ? false, localWorkspace ? null
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  mc-rtc,
+  eigen-quadprog,
+  gram-savitzky-golay,
+  jrl-cmakemodules,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (_finalAttrs: {
   pname = "dcm-vrptask";
   version = "0.1.0";
 
-  src = if useLocal then
-      builtins.trace "Using local workspace for dcm-vrptask: ${localWorkspace}/DCM_VRPTask"
-      (builtins.path {
-        path = "${localWorkspace}/DCM_VRPTask";
-        name = "dcm-vrptask-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for dcm-vrptask: ${localWorkspace}/DCM_VRPTask" (
+        builtins.path {
+          path = "${localWorkspace}/DCM_VRPTask";
+          name = "dcm-vrptask-src";
+        }
+      )
     else
       fetchFromGitHub {
         owner = "Hugo-L3174";
@@ -22,18 +32,22 @@ stdenv.mkDerivation (finalAttrs: {
         hash = "";
       };
 
-  nativeBuildInputs = [ cmake jrl-cmakemodules ];
-  propagatedBuildInputs =
-    [
-      mc-rtc gram-savitzky-golay eigen-quadprog
-    ];
+  nativeBuildInputs = [
+    cmake
+    jrl-cmakemodules
+  ];
+  propagatedBuildInputs = [
+    mc-rtc
+    gram-savitzky-golay
+    eigen-quadprog
+  ];
 
   doCheck = false;
 
   meta = with lib; {
     description = "DCM-VRP tracking task for mc-rtc";
-    homepage    = "https://github.com/Hugo-L3174/DCM_VRPTask";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/Hugo-L3174/DCM_VRPTask";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/mc-rtc/controllers/polytopeController/default.nix
+++ b/pkgs/mc-rtc/controllers/polytopeController/default.nix
@@ -1,19 +1,28 @@
 {
-stdenv, lib, fetchFromGitHub,
-cmake, mc-dynamic-polytopes, mc-force-shoe-plugin, dcm-vrptask,
-useLocal ? false, localWorkspace ? null
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  mc-dynamic-polytopes,
+  mc-force-shoe-plugin,
+  dcm-vrptask,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "polytopeController";
   version = "1.0.0";
 
-  src = if useLocal then
+  src =
+    if useLocal then
       builtins.trace "Using local workspace for polytopeController: ${localWorkspace}/polytopeController"
-      (builtins.path {
-        path = "${localWorkspace}/polytopeController";
-        name = "polytopeController-src";
-      })
+        (
+          builtins.path {
+            path = "${localWorkspace}/polytopeController";
+            name = "polytopeController-src";
+          }
+        )
     else
       fetchFromGitHub {
         owner = "Hugo-L3174";
@@ -23,10 +32,11 @@ stdenv.mkDerivation (finalAttrs: {
       };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs =
-    [
-      mc-dynamic-polytopes mc-force-shoe-plugin dcm-vrptask
-    ];
+  propagatedBuildInputs = [
+    mc-dynamic-polytopes
+    mc-force-shoe-plugin
+    dcm-vrptask
+  ];
 
   cmakeFlags = [
     "-DMC_RTC_HONOR_INSTALL_PREFIX=ON"
@@ -37,8 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Controller to test dynamic stability approaches";
-    homepage    = "https://github.com/Hugo-L3174/polytopeController";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/Hugo-L3174/polytopeController";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/mc-rtc/controllers/polytopeController/mc-dynamic-polytopes.nix
+++ b/pkgs/mc-rtc/controllers/polytopeController/mc-dynamic-polytopes.nix
@@ -1,18 +1,29 @@
-{ stdenv, lib, fetchFromGitHub, fetchgit,
-cmake, mc-rtc, politopix, jrl-cmakemodules,
-useLocal ? false, localWorkspace ? null
+{
+  stdenv,
+  lib,
+  fetchgit,
+  cmake,
+  mc-rtc,
+  politopix,
+  jrl-cmakemodules,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (_finalAttrs: {
   pname = "mc-dynamic-polytopes";
   version = "1.0.1";
 
-  src = if useLocal then
-      builtins.trace "Using local workspace for mc-dynamic-polytopes: ${localWorkspace}/mc_dynamic_polytopes"
-      (builtins.path {
-        path = "${localWorkspace}/mc_dynamic_polytopes";
-        name = "mc-dynamic-polytopes-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace
+        "Using local workspace for mc-dynamic-polytopes: ${localWorkspace}/mc_dynamic_polytopes"
+        (
+          builtins.path {
+            path = "${localWorkspace}/mc_dynamic_polytopes";
+            name = "mc-dynamic-polytopes-src";
+          }
+        )
     else
       # FIXME: The release archive is missing jrl-cmakemodules, we should use v2 anyways
       # fetchFromGitHub {
@@ -34,11 +45,14 @@ stdenv.mkDerivation (finalAttrs: {
         hash = "";
       };
 
-  nativeBuildInputs = [ cmake jrl-cmakemodules ];
-  propagatedBuildInputs =
-    [
-      mc-rtc politopix
-    ];
+  nativeBuildInputs = [
+    cmake
+    jrl-cmakemodules
+  ];
+  propagatedBuildInputs = [
+    mc-rtc
+    politopix
+  ];
 
   cmakeFlags = [
     "-DMC_RTC_HONOR_INSTALL_PREFIX=ON"
@@ -48,8 +62,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "mc_rtc library for dynamic balance polytopes computations using politopix";
-    homepage    = "https://github.com/Hugo-L3174/mc_dynamic_polytopes";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/Hugo-L3174/mc_dynamic_polytopes";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/mc-rtc/controllers/polytopeController/mc-dynamic-polytopes.nix
+++ b/pkgs/mc-rtc/controllers/polytopeController/mc-dynamic-polytopes.nix
@@ -41,7 +41,8 @@ stdenv.mkDerivation (_finalAttrs: {
       # https://github.com/Hugo-L3174/mc_dynamic_polytopes/pull/6 future v1.0.1
       fetchgit {
         url = "https://github.com/Hugo-L3174/mc_dynamic_polytopes.git";
-        rev = "75a0d1ca6dc703ba2ad8ed79d8ae647496682ca8"; # or a commit hash or branch name
+        # PR#6
+        rev = "35b98db7feb8d10e95737c419ec54ea30ef9780a"; # or a commit hash or branch name
         hash = "";
       };
 

--- a/pkgs/mc-rtc/mc-mujoco/default.nix
+++ b/pkgs/mc-rtc/mc-mujoco/default.nix
@@ -1,31 +1,44 @@
 {
-stdenv, lib, fetchgit,
-makeWrapper,
-mc-mujoco-robots,
-cmake, jrl-cmakemodules,
-mc-rtc, mujoco, pugixml,
-libtorch-bin # for RL examples, should be an option
-# XXX see if all of these are really necessary
-,    libXrandr ,    libXinerama ,    libXcursor ,    libX11 ,    libXi ,    libXext
-,    glew
-,     glfw3
-, mc-rtc-imgui
-, imguizmo
-, useLocal ? false, localWorkspace ? null
+  stdenv,
+  lib,
+  fetchgit,
+  makeWrapper,
+  mc-mujoco-robots,
+  cmake,
+  jrl-cmakemodules,
+  mc-rtc,
+  mujoco,
+  pugixml,
+  libtorch-bin, # for RL examples, should be an option
+  # XXX see if all of these are really necessary
+  libXrandr,
+  libXinerama,
+  libXcursor,
+  libX11,
+  libXi,
+  libXext,
+  glew,
+  glfw3,
+  mc-rtc-imgui,
+  imguizmo,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (_finalAttrs: {
   pname = "mc-mujoco";
   version = "0.0.0";
 
   dontBuild = true;
 
-  src = if useLocal then
-      builtins.trace "Using local workspace for mc-mujoco: ${localWorkspace}/mc_mujoco"
-      (builtins.path {
-        path = "${localWorkspace}/mc_mujoco";
-        name = "mc-mujoco-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for mc-mujoco: ${localWorkspace}/mc_mujoco" (
+        builtins.path {
+          path = "${localWorkspace}/mc_mujoco";
+          name = "mc-mujoco-src";
+        }
+      )
     else
       fetchgit {
         url = "https://github.com/arntanguy/mc_mujoco.git";
@@ -36,24 +49,27 @@ stdenv.mkDerivation (finalAttrs: {
         fetchSubmodules = true;
       };
 
-  nativeBuildInputs = [ cmake jrl-cmakemodules makeWrapper ];
-  propagatedBuildInputs =
-    [
-      mc-rtc
-      mc-rtc-imgui
-      imguizmo
-      mujoco
-      pugixml
-      libXrandr
-      libXinerama
-      libXcursor
-      libX11
-      libXi
-      libXext
-      glew
-      glfw3
-      libtorch-bin
-    ];
+  nativeBuildInputs = [
+    cmake
+    jrl-cmakemodules
+    makeWrapper
+  ];
+  propagatedBuildInputs = [
+    mc-rtc
+    mc-rtc-imgui
+    imguizmo
+    mujoco
+    pugixml
+    libXrandr
+    libXinerama
+    libXcursor
+    libX11
+    libXi
+    libXext
+    glew
+    glfw3
+    libtorch-bin
+  ];
 
   cmakeFlags = [
     "-DMC_RTC_HONOR_INSTALL_PREFIX=ON"
@@ -73,8 +89,8 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     mainProgram = "mc_mujoco";
     description = "Plugin to update some parameters of a robot model live or from configuration ";
-    homepage    = "https://github.com/jrl-umi3218/mc_mujoco";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/mc_mujoco";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/mc-rtc/mc-mujoco/robots/default.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/default.nix
@@ -1,15 +1,18 @@
 {
-stdenv, symlinkJoin,
-jvrc1-mj-description,
-env-mj-description,
-robots ? []
+  symlinkJoin,
+  jvrc1-mj-description,
+  env-mj-description,
+  robots ? [ ],
 }:
 
 symlinkJoin {
   name = "mc-mujoco-robots";
-  paths = [jvrc1-mj-description env-mj-description] ++ robots;
-  meta =
-  {
+  paths = [
+    jvrc1-mj-description
+    env-mj-description
+  ]
+  ++ robots;
+  meta = {
     description = "Robots for mc-mujoco symlinked into a single folder";
   };
 }

--- a/pkgs/mc-rtc/mc-mujoco/robots/env-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/env-mj-description.nix
@@ -1,24 +1,32 @@
-{ stdenv, lib, fetchFromGitHub, cmake,
-useLocal ? false, localWorkspace ? null }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "env-mj-description";
   version = "1.0.0";
   srcPath = "${localWorkspace}/env_mj_description";
 
-  src = if useLocal then
-        builtins.trace "Using local workspace for ${finalAttrs.pname}: ${finalAttrs.srcPath}"
-        (builtins.path {
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for ${finalAttrs.pname}: ${finalAttrs.srcPath}" (
+        builtins.path {
           path = "${finalAttrs.srcPath}";
           name = "${finalAttrs.pname}-src";
-        })
-      else
-        fetchFromGitHub {
-          owner = "isri-aist";
-          repo = "env_mj_description";
-          tag = "v${finalAttrs.version}";
-          hash = "sha256-PiSbUX7+nSk8mNLsRBQGvo+sf/XCyN9xgcsY4BweyZo=";
-        };
+        }
+      )
+    else
+      fetchFromGitHub {
+        owner = "isri-aist";
+        repo = "env_mj_description";
+        tag = "v${finalAttrs.version}";
+        hash = "sha256-PiSbUX7+nSk8mNLsRBQGvo+sf/XCyN9xgcsY4BweyZo=";
+      };
 
   nativeBuildInputs = [ cmake ];
 
@@ -34,8 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Environment robot data for mc_mujoco";
-    homepage    = "https://github.com/jrl-umi3218/mc_env_description";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/mc_env_description";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/mc-rtc/mc-mujoco/robots/g1-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/g1-mj-description.nix
@@ -1,9 +1,21 @@
-{ stdenv, lib, fetchFromGitHub, cmake
-, useLocal ? false, localWorkspace ? null
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
 import ./mj-description-base.nix {
-  inherit stdenv lib fetchFromGitHub cmake useLocal localWorkspace;
+  inherit
+    stdenv
+    lib
+    fetchFromGitHub
+    cmake
+    useLocal
+    localWorkspace
+    ;
   pname = "g1-mj-description";
   repo = "g1_mj_description";
   hash = "sha256-vm03l9AWxvwJEXgrU0bv8Krf1V1AizHqMxnjXj232K4=";

--- a/pkgs/mc-rtc/mc-mujoco/robots/h1-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/h1-mj-description.nix
@@ -1,9 +1,21 @@
-{ stdenv, lib, fetchFromGitHub, cmake
-, useLocal ? false, localWorkspace ? null
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
 import ./mj-description-base.nix {
-  inherit stdenv lib fetchFromGitHub cmake useLocal localWorkspace;
+  inherit
+    stdenv
+    lib
+    fetchFromGitHub
+    cmake
+    useLocal
+    localWorkspace
+    ;
   pname = "h1-mj-description";
   repo = "h1_mj_description";
 }

--- a/pkgs/mc-rtc/mc-mujoco/robots/hrp4-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/hrp4-mj-description.nix
@@ -1,24 +1,33 @@
-{ stdenv, lib, cmake,
-useLocal ? false, localWorkspace ? null }:
+{
+  stdenv,
+  lib,
+  cmake,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   version = "0.0.0";
   pname = "hrp4-mj-description";
 
-  src = if useLocal then
-        builtins.trace "Using local workspace for ${finalAttrs.pname}: ${localWorkspace}/hrp4_mj_description"
-        (builtins.path {
-          path = "${localWorkspace}/hrp4_mj_description";
-          name = "${finalAttrs.pname}-src";
-        })
-      else
-        # XXX should we merge with https://gite.lirmm.fr/mc-hrp4/hrp4_mj_description
-        # I don't remember what hugo changes were
-        # TODO release
-        builtins.fetchGit {
-          url = "git@gite.lirmm.fr:hlefevre/hrp4_mj_descrition";
-          rev = "5f8df7e6eeb5153ee381394312f5700f36bda1e2";
-        };
+  src =
+    if useLocal then
+      builtins.trace
+        "Using local workspace for ${finalAttrs.pname}: ${localWorkspace}/hrp4_mj_description"
+        (
+          builtins.path {
+            path = "${localWorkspace}/hrp4_mj_description";
+            name = "${finalAttrs.pname}-src";
+          }
+        )
+    else
+      # XXX should we merge with https://gite.lirmm.fr/mc-hrp4/hrp4_mj_description
+      # I don't remember what hugo changes were
+      # TODO release
+      builtins.fetchGit {
+        url = "git@gite.lirmm.fr:hlefevre/hrp4_mj_descrition";
+        rev = "5f8df7e6eeb5153ee381394312f5700f36bda1e2";
+      };
 
   nativeBuildInputs = [ cmake ];
 
@@ -30,8 +39,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "HRP-4 simulation robot model mc_mujoco";
-    homepage    = "https://gite.lirmm.fr/hlefevre/hrp4_mj_description";
+    homepage = "https://gite.lirmm.fr/hlefevre/hrp4_mj_description";
     # license     = licenses.bsd2;
-    platforms   = platforms.all;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/mc-rtc/mc-mujoco/robots/hrp4cr-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/hrp4cr-mj-description.nix
@@ -1,24 +1,32 @@
-{ stdenv, lib, fetchFromGitHub, cmake,
-useLocal ? false, localWorkspace ? null }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   version = "1.0.0";
   pname = "hrp4cr-mj-description";
   srcPath = if localWorkspace != null then "${localWorkspace}/hrp4cr_mj_description" else null;
 
-  src = if useLocal then
-        builtins.trace "Using local workspace for ${finalAttrs.pname}: ${finalAttrs.srcPath}"
-        (builtins.path {
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for ${finalAttrs.pname}: ${finalAttrs.srcPath}" (
+        builtins.path {
           path = "${finalAttrs.srcPath}";
           name = "${finalAttrs.pname}-src";
-        })
-      else
-        fetchFromGitHub {
-          owner = "isri-aist";
-          repo = "hrp4cr_mj_description";
-          tag = "v${finalAttrs.version}";
-          hash = "";
-        };
+        }
+      )
+    else
+      fetchFromGitHub {
+        owner = "isri-aist";
+        repo = "hrp4cr_mj_description";
+        tag = "v${finalAttrs.version}";
+        hash = "";
+      };
 
   nativeBuildInputs = [ cmake ];
 
@@ -30,8 +38,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "hrp4cr simulation robot model mc_mujoco";
-    homepage    = "https://github.com/jrl-umi3218/hrp4cr_env_description";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/hrp4cr_env_description";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/mc-rtc/mc-mujoco/robots/hrp5p-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/hrp5p-mj-description.nix
@@ -1,23 +1,33 @@
-{ stdenv, lib, fetchFromGitHub, cmake,
-useLocal ? false, localWorkspace ? null }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   version = "1.0.0";
   pname = "hrp5p-mj-description";
 
-  src = if useLocal then
-        builtins.trace "Using local workspace for ${finalAttrs.pname}: ${localWorkspace}/hrp5p_mj_description"
-        (builtins.path {
-          path = "${localWorkspace}/hrp5p_mj_description";
-          name = "${finalAttrs.pname}-src";
-        })
-      else
-        fetchFromGitHub {
-          owner = "isri-aist";
-          repo = "hrp5p_mj_description";
-          tag = "v${finalAttrs.version}";
-          hash = "sha256-uLrXuYI2w+fg5a/WOZfs8kj5QB3NT35sziN3YsDmRmg=";
-        };
+  src =
+    if useLocal then
+      builtins.trace
+        "Using local workspace for ${finalAttrs.pname}: ${localWorkspace}/hrp5p_mj_description"
+        (
+          builtins.path {
+            path = "${localWorkspace}/hrp5p_mj_description";
+            name = "${finalAttrs.pname}-src";
+          }
+        )
+    else
+      fetchFromGitHub {
+        owner = "isri-aist";
+        repo = "hrp5p_mj_description";
+        tag = "v${finalAttrs.version}";
+        hash = "sha256-uLrXuYI2w+fg5a/WOZfs8kj5QB3NT35sziN3YsDmRmg=";
+      };
 
   nativeBuildInputs = [ cmake ];
 
@@ -33,8 +43,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "hrp5p simulation robot model mc_mujoco";
-    homepage    = "https://github.com/jrl-umi3218/hrp5p_env_description";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/hrp5p_env_description";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/mc-rtc/mc-mujoco/robots/jvrc1-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/jvrc1-mj-description.nix
@@ -1,24 +1,34 @@
-{ stdenv, lib, fetchFromGitHub, cmake,
-useLocal ? false, localWorkspace ? null }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   version = "1.0.0";
   pname = "jvrc1-mj-description";
   srcPath = "${localWorkspace}/jvrc_mj_description";
 
-  src = if useLocal then
-        builtins.trace "Using local workspace for ${finalAttrs.pname}: ${localWorkspace}/jvrc_mj_description"
-        (builtins.path {
-          path = "${localWorkspace}/jvrc_mj_description";
-          name = "${finalAttrs.pname}-src";
-        })
-      else
-        fetchFromGitHub {
-          owner = "isri-aist";
-          repo = "jvrc_mj_description";
-          tag = "v${finalAttrs.version}";
-          hash = "sha256-uLrXuYI2w+fg5a/WOZfs8kj5QB3NT35sziN3YsDmRmg=";
-        };
+  src =
+    if useLocal then
+      builtins.trace
+        "Using local workspace for ${finalAttrs.pname}: ${localWorkspace}/jvrc_mj_description"
+        (
+          builtins.path {
+            path = "${localWorkspace}/jvrc_mj_description";
+            name = "${finalAttrs.pname}-src";
+          }
+        )
+    else
+      fetchFromGitHub {
+        owner = "isri-aist";
+        repo = "jvrc_mj_description";
+        tag = "v${finalAttrs.version}";
+        hash = "sha256-uLrXuYI2w+fg5a/WOZfs8kj5QB3NT35sziN3YsDmRmg=";
+      };
 
   nativeBuildInputs = [ cmake ];
 
@@ -34,8 +44,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "JVRC1 simulation robot model mc_mujoco";
-    homepage    = "https://github.com/jrl-umi3218/jvrc_env_description";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/jvrc_env_description";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/mc-rtc/mc-mujoco/robots/mj-description-base.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/mj-description-base.nix
@@ -1,6 +1,16 @@
-{ stdenv, lib, fetchFromGitHub, cmake
-, useLocal ? false, localWorkspace ? null
-, pname, owner ? "isri-aist", repo, description ? null, version ? "1.0.0", hash ? null
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  useLocal ? false,
+  localWorkspace ? null,
+  pname,
+  owner ? "isri-aist",
+  repo,
+  description ? null,
+  version ? "1.0.0",
+  hash ? null,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -8,12 +18,14 @@ stdenv.mkDerivation (finalAttrs: {
   pname = pname;
   srcPath = if localWorkspace != null then "${localWorkspace}/${repo}" else null;
 
-  src = if useLocal then
-    builtins.trace "Using local workspace for ${finalAttrs.pname}: ${finalAttrs.srcPath}"
-      (builtins.path {
-        path = "${finalAttrs.srcPath}";
-        name = "${finalAttrs.pname}-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for ${finalAttrs.pname}: ${finalAttrs.srcPath}" (
+        builtins.path {
+          path = "${finalAttrs.srcPath}";
+          name = "${finalAttrs.pname}-src";
+        }
+      )
     else
       fetchFromGitHub {
         owner = owner;
@@ -35,9 +47,10 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   meta = with lib; {
-    description = if description != null then description else "${pname} simulation robot model for mc_mujoco";
-    homepage    = "https://github.com/${owner}/${repo}";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    description =
+      if description != null then description else "${pname} simulation robot model for mc_mujoco";
+    homepage = "https://github.com/${owner}/${repo}";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/mc-rtc/mc-mujoco/robots/rhps1-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/rhps1-mj-description.nix
@@ -1,22 +1,31 @@
-{ stdenv, lib, fetchFromGitHub, cmake,
-useLocal ? false, localWorkspace ? null }:
+{
+  stdenv,
+  lib,
+  cmake,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   version = "1.0.0";
   pname = "rhps1-mj-description";
 
-  src = if useLocal then
-        builtins.trace "Using local workspace for ${finalAttrs.pname}: ${localWorkspace}/rhps1_mj_description"
-        (builtins.path {
-          path = "${localWorkspace}/rhps1_mj_description";
-          name = "${finalAttrs.pname}-src";
-        })
-      else
-        builtins.fetchGit {
-          url = "git@github.com:isri-aist/rhps1_mj_description";
-          # Release v1.0.0
-          rev = "ac2d198b21b6f431fffc2c93ad03b04f98c4135a";
-        };
+  src =
+    if useLocal then
+      builtins.trace
+        "Using local workspace for ${finalAttrs.pname}: ${localWorkspace}/rhps1_mj_description"
+        (
+          builtins.path {
+            path = "${localWorkspace}/rhps1_mj_description";
+            name = "${finalAttrs.pname}-src";
+          }
+        )
+    else
+      builtins.fetchGit {
+        url = "git@github.com:isri-aist/rhps1_mj_description";
+        # Release v1.0.0
+        rev = "ac2d198b21b6f431fffc2c93ad03b04f98c4135a";
+      };
 
   nativeBuildInputs = [ cmake ];
 
@@ -32,8 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "rhps1 simulation robot model mc_mujoco";
-    homepage    = "https://github.com/jrl-umi3218/rhps1_env_description";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/rhps1_env_description";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/mc-rtc/mc-mujoco/robots/ur5e-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/ur5e-mj-description.nix
@@ -1,9 +1,21 @@
-{ stdenv, lib, fetchFromGitHub, cmake
-, useLocal ? false, localWorkspace ? null
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
 import ./mj-description-base.nix {
-  inherit stdenv lib fetchFromGitHub cmake useLocal localWorkspace;
+  inherit
+    stdenv
+    lib
+    fetchFromGitHub
+    cmake
+    useLocal
+    localWorkspace
+    ;
   pname = "ur5e-mj-description";
   repo = "ur5e_mj_description";
   version = "1.0.0";

--- a/pkgs/mc-rtc/mc-rtc-common.nix
+++ b/pkgs/mc-rtc/mc-rtc-common.nix
@@ -1,21 +1,27 @@
-{ lib, useLocal ? false, localWorkspace ? null, fetchgit }:
+{
+  useLocal ? false,
+  localWorkspace ? null,
+  fetchgit,
+}:
 
 let
   version = "2.14.1";
-  src = if useLocal then
-    builtins.trace "Using local workspace for mc_rtc: ${localWorkspace}/mc_rtc"
-    (builtins.path {
-      path = "${localWorkspace}/mc_rtc";
-      name = "mc-rtc-src";
-    })
-  else
-    fetchgit {
-      url = "https://github.com/jrl-umi3218/mc_rtc";
-      # PR 495 merged (HONOR_INSTALL_PREFIX)
-      rev = "1d5f6da998110acba73c327831903ee933ac884f";
-      fetchSubmodules = true;
-      sha256 = "sha256-soiG0+SK9PmJCrPRpaJt3Ej1SSxUg9kT8UlMajwUfqg=";
-    };
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for mc_rtc: ${localWorkspace}/mc_rtc" (
+        builtins.path {
+          path = "${localWorkspace}/mc_rtc";
+          name = "mc-rtc-src";
+        }
+      )
+    else
+      fetchgit {
+        url = "https://github.com/jrl-umi3218/mc_rtc";
+        # PR 495 merged (HONOR_INSTALL_PREFIX)
+        rev = "1d5f6da998110acba73c327831903ee933ac884f";
+        fetchSubmodules = true;
+        sha256 = "sha256-soiG0+SK9PmJCrPRpaJt3Ej1SSxUg9kT8UlMajwUfqg=";
+      };
 in
 {
   inherit version src;

--- a/pkgs/mc-rtc/mc-rtc-python-utils.nix
+++ b/pkgs/mc-rtc/mc-rtc-python-utils.nix
@@ -1,10 +1,18 @@
-{ lib, buildRosPackage, fetchgit, cmake, python313Packages, mc-rtc, useLocal ? false, localWorkspace ? null,
-    rosidl-default-generators,
-    geometry-msgs,
-    rosidl-default-runtime,
-    rosidl-typesupport-c,
-    rosidl-typesupport-cpp,
-    pkg-config
+{
+  lib,
+  buildRosPackage,
+  fetchgit,
+  cmake,
+  python313Packages,
+  mc-rtc,
+  useLocal ? false,
+  localWorkspace ? null,
+  rosidl-default-generators,
+  geometry-msgs,
+  rosidl-default-runtime,
+  rosidl-typesupport-c,
+  rosidl-typesupport-cpp,
+  pkg-config,
 }:
 
 let
@@ -17,17 +25,21 @@ buildRosPackage {
   inherit (common) version src;
   format = "other"; # built by cmake
 
-  nativeBuildInputs = [ cmake pkg-config ];
-  propagatedBuildInputs = [ mc-rtc python313Packages.gitpython ]
-  ++
-  [
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+  propagatedBuildInputs = [
+    mc-rtc
+    python313Packages.gitpython
+  ]
+  ++ [
     rosidl-default-generators
     geometry-msgs
     rosidl-default-runtime
     rosidl-typesupport-c
     rosidl-typesupport-cpp
-   ];
-
+  ];
 
   cmakeFlags = [
     "-DPROJECT_USE_CMAKE_EXPORT=OFF"
@@ -51,13 +63,13 @@ buildRosPackage {
     echo "AMENT_PREFIX_PATH=$AMENT_PREFIX_PATH"
     echo "CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH"
   '';
- 
+
   doCheck = false;
 
   meta = with lib; {
     description = "Python utilities from mc-rtc";
-    homepage    = "https://github.com/jrl-umi3218/mc_rtc";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/mc_rtc";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix
+++ b/pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix
@@ -1,32 +1,38 @@
 # The main purpose of this derivation is to provide an mc_rtc environment
 # with runtime dependencies available, e.g robot modules, controllers, observers and plugins
-# 
+#
 # This is achieved by:
 # - declaring the runtime dependencies in either robots, controllers, observers and plugins list
 # - this derivation generates and mc_rtc.yaml configuration with runtime path to these dependencies
 #   e.g in ControllerModulePaths, ObserverModulePaths, etc
-{ stdenv, lib, writeTextFile
-, mc-rtc
-, MainRobot ? null # default robot module name
-, Enabled ? null # default controller
-, Timestep ? null # default timestep
-, configs ? [] # extra paths to mc_rtc.yaml
-, robots ? []
-, controllers ? []
-, observers ? []
-, plugins ? []
-, apps ? []
-, pname ? "mc-rtc-superbuild-standalone"
-, traceRuntimeDependencies ? false
+{
+  stdenv,
+  lib,
+  writeTextFile,
+  mc-rtc,
+  MainRobot ? null, # default robot module name
+  Enabled ? null, # default controller
+  Timestep ? null, # default timestep
+  configs ? [ ], # extra paths to mc_rtc.yaml
+  robots ? [ ],
+  controllers ? [ ],
+  observers ? [ ],
+  plugins ? [ ],
+  apps ? [ ],
+  pname ? "mc-rtc-superbuild-standalone",
+  traceRuntimeDependencies ? false,
 }:
 
 let
   # Helper to build YAML lists
   toYamlList = paths: lib.concatMapStringsSep ", " (p: "\"${p}\"") paths;
 
-  traceGroup = name: pkgs: if traceRuntimeDependencies then
-    map (p: builtins.trace "${pname} ${name}: ${toString p}" p) pkgs
-  else pkgs;
+  traceGroup =
+    name: pkgs:
+    if traceRuntimeDependencies then
+      map (p: builtins.trace "${pname} ${name}: ${toString p}" p) pkgs
+    else
+      pkgs;
 
   default_mc_rtc_yaml = writeTextFile {
     name = "mc_rtc.yaml";
@@ -51,7 +57,7 @@ let
   };
 in
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (_finalAttrs: {
   pname = builtins.trace "pname: ${pname}" "${pname}";
   version = mc-rtc.version;
   src = null;
@@ -60,12 +66,14 @@ stdenv.mkDerivation (finalAttrs: {
   dontBuild = true;
   dontWrapQtApps = true;
 
-  propagatedBuildInputs = [ mc-rtc ]
-    ++ traceGroup "apps" apps
-    ++ traceGroup "robots" robots
-    ++ traceGroup "plugins" plugins
-    ++ traceGroup "controllers" controllers
-    ++ traceGroup "observers" observers;
+  propagatedBuildInputs = [
+    mc-rtc
+  ]
+  ++ traceGroup "apps" apps
+  ++ traceGroup "robots" robots
+  ++ traceGroup "plugins" plugins
+  ++ traceGroup "controllers" controllers
+  ++ traceGroup "observers" observers;
 
   installPhase = ''
     mkdir -p $out/etc
@@ -73,11 +81,21 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    inherit mc-rtc robots controllers observers plugins apps configs pname;
+    inherit
+      mc-rtc
+      robots
+      controllers
+      observers
+      plugins
+      apps
+      configs
+      pname
+      ;
   };
 
   meta = mc-rtc.meta // {
-    description = mc-rtc.meta.description + " (meta-package with robots, controllers, observers, plugins)";
+    description =
+      mc-rtc.meta.description + " (meta-package with robots, controllers, observers, plugins)";
   };
 
   # Set MC_RTC_CONTROLLER_CONFIG to point to the generated YAML

--- a/pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix
+++ b/pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix
@@ -10,27 +10,31 @@
   lib,
   writeTextFile,
   mc-rtc,
-  MainRobot ? null, # default robot module name
-  Enabled ? null, # default controller
-  Timestep ? null, # default timestep
-  configs ? [ ], # extra paths to mc_rtc.yaml
-  robots ? [ ],
-  controllers ? [ ],
-  observers ? [ ],
-  plugins ? [ ],
-  apps ? [ ],
-  pname ? "mc-rtc-superbuild-standalone",
-  traceRuntimeDependencies ? false,
+  superbuildArgs ? { },
+  ...
 }:
 
 let
+  cfg = superbuildArgs // {
+    pname = superbuildArgs.pname or "mc-rtc-superbuild";
+    MainRobot = superbuildArgs.MainRobot or "JVRC1";
+    Enabled = superbuildArgs.Enabled or "CoM";
+    Timestep = superbuildArgs.Timestep or 0.005;
+    configs = superbuildArgs.configs or [ ];
+    robots = superbuildArgs.robots or [ ];
+    controllers = superbuildArgs.controllers or [ ];
+    observers = superbuildArgs.observers or [ ];
+    plugins = superbuildArgs.plugins or [ ];
+    apps = superbuildArgs.apps or [ ];
+  };
+
   # Helper to build YAML lists
   toYamlList = paths: lib.concatMapStringsSep ", " (p: "\"${p}\"") paths;
 
   traceGroup =
     name: pkgs:
-    if traceRuntimeDependencies then
-      map (p: builtins.trace "${pname} ${name}: ${toString p}" p) pkgs
+    if cfg.traceRuntimeDependencies or false then
+      map (p: builtins.trace "${cfg.pname} ${name}: ${toString p}" p) pkgs
     else
       pkgs;
 
@@ -39,17 +43,17 @@ let
     destination = "/etc/mc_rtc.yaml";
     text = ''
       ---
-      # This mc_rtc.yaml file was generated from the mc-rtc-superbuild-standalone nix derivation (pname: ${pname})
+      # This mc_rtc.yaml file was generated from the mc-rtc-superbuild-standalone nix derivation (pname: ${cfg.pname})
 
-      ${lib.optionalString (MainRobot != null) "MainRobot: ${MainRobot}\n"}
-      ${lib.optionalString (Enabled != null) "Enabled: [${Enabled}]\n"}
-      ${lib.optionalString (Timestep != null) "Timestep: ${toString Timestep}\n"}
+      ${lib.optionalString (cfg.MainRobot or null != null) "MainRobot: ${cfg.MainRobot}\n"}
+      ${lib.optionalString (cfg.Enabled or null != null) "Enabled: [${cfg.Enabled}]\n"}
+      ${lib.optionalString (cfg.Timestep or null != null) "Timestep: ${toString (cfg.Timestep or "")}\n"}
 
       # Dynamically generated module paths
-      ControllerModulePaths: [${toYamlList (map (p: "${p}/lib/mc_controller") (controllers))}]
-      RobotModulePaths: [${toYamlList (map (p: "${p}/lib/mc_robots") (robots))}]
-      ObserverModulePaths: [${toYamlList (map (p: "${p}/lib/mc_observers") (observers))}]
-      GlobalPluginPaths: [${toYamlList (map (p: "${p}/lib/mc_plugins") (plugins))}]
+      ControllerModulePaths: [${toYamlList (map (p: "${p}/lib/mc_controller") (cfg.controllers or [ ]))}]
+      RobotModulePaths: [${toYamlList (map (p: "${p}/lib/mc_robots") (cfg.robots or [ ]))}]
+      ObserverModulePaths: [${toYamlList (map (p: "${p}/lib/mc_observers") (cfg.observers or [ ]))}]
+      GlobalPluginPaths: [${toYamlList (map (p: "${p}/lib/mc_plugins") (cfg.plugins or [ ]))}]
 
       # Ignore ~/.config/mc_rtc/mc_rtc.yaml so that even in impure mode it does not interfere
       LoadUserConfiguration: false
@@ -57,8 +61,8 @@ let
   };
 in
 
-stdenv.mkDerivation (_finalAttrs: {
-  pname = builtins.trace "pname: ${pname}" "${pname}";
+stdenv.mkDerivation {
+  pname = builtins.trace "pname: ${cfg.pname}" cfg.pname;
   version = mc-rtc.version;
   src = null;
   dontUnpack = true;
@@ -69,11 +73,11 @@ stdenv.mkDerivation (_finalAttrs: {
   propagatedBuildInputs = [
     mc-rtc
   ]
-  ++ traceGroup "apps" apps
-  ++ traceGroup "robots" robots
-  ++ traceGroup "plugins" plugins
-  ++ traceGroup "controllers" controllers
-  ++ traceGroup "observers" observers;
+  ++ traceGroup "apps" (cfg.apps or [ ])
+  ++ traceGroup "robots" (cfg.robots or [ ])
+  ++ traceGroup "plugins" (cfg.plugins or [ ])
+  ++ traceGroup "controllers" (cfg.controllers or [ ])
+  ++ traceGroup "observers" (cfg.observers or [ ]);
 
   installPhase = ''
     mkdir -p $out/etc
@@ -81,16 +85,8 @@ stdenv.mkDerivation (_finalAttrs: {
   '';
 
   passthru = {
-    inherit
-      mc-rtc
-      robots
-      controllers
-      observers
-      plugins
-      apps
-      configs
-      pname
-      ;
+    inherit mc-rtc;
+    superbuildArgs = cfg;
   };
 
   meta = mc-rtc.meta // {
@@ -103,4 +99,4 @@ stdenv.mkDerivation (_finalAttrs: {
   #   export MC_RTC_CONTROLLER_CONFIG="$out/etc/mc_rtc.yaml"
   #   echo "MC_RTC_CONTROLLER_CONFIG set to $MC_RTC_CONTROLLER_CONFIG"
   # '';
-})
+}

--- a/pkgs/mc-rtc/mc-rtc-superbuild-symlinkjoin.nix
+++ b/pkgs/mc-rtc/mc-rtc-superbuild-symlinkjoin.nix
@@ -1,18 +1,19 @@
 # The main purpose of this derivation is to provide an mc_rtc environment
 # with runtime dependencies available, e.g robot modules, controllers, observers and plugins
-{ stdenv, lib, writeTextFile
-, symlinkJoin
-, rsync
-, mc-rtc
-, MainRobot ? "JVRC1"
-, Enabled ? "CoM"
-, Timestep ? 0.005
-, configs ? []
-, robots ? []
-, controllers ? []
-, observers ? []
-, plugins ? []
-, apps ? []
+{
+  stdenv,
+  symlinkJoin,
+  rsync,
+  mc-rtc,
+  MainRobot ? "JVRC1",
+  Enabled ? "CoM",
+  Timestep ? 0.005,
+  configs ? [ ],
+  robots ? [ ],
+  controllers ? [ ],
+  observers ? [ ],
+  plugins ? [ ],
+  apps ? [ ],
 }:
 
 let
@@ -29,7 +30,10 @@ stdenv.mkDerivation {
   dontConfigure = true;
   dontBuild = true;
 
-  buildInputs = [ rsync merged ];
+  buildInputs = [
+    rsync
+    merged
+  ];
 
   installPhase = ''
     mkdir $out
@@ -66,10 +70,19 @@ stdenv.mkDerivation {
   '';
 
   passthru = {
-    inherit mc-rtc robots controllers observers plugins apps configs;
+    inherit
+      mc-rtc
+      robots
+      controllers
+      observers
+      plugins
+      apps
+      configs
+      ;
   };
 
   meta = mc-rtc.meta // {
-    description = mc-rtc.meta.description + " (meta-package with robots, controllers, observers, plugins)";
+    description =
+      mc-rtc.meta.description + " (meta-package with robots, controllers, observers, plugins)";
   };
 }

--- a/pkgs/mc-rtc/mc-rtc.nix
+++ b/pkgs/mc-rtc/mc-rtc.nix
@@ -1,46 +1,106 @@
 # Builds the base mc-rtc version, without any plugins (controllers, robots, etc)
 # See mc-rtc-superbuild.nix for a full derivation with optional plugins
 
-{ lib, buildRosPackage, stdenv, fetchgit, cmake, pkg-config,
-tasks, tvm, eigen-quadprog, libtool, geos, spdlog, ndcurves, mc-rtc-data,
-state-observation, nanomsg, libnotify, rapidjson, boost, mesh-sampling,
-python313Packages, qt5,
-eigen-fmt,
-doxygen, bundler,# Ruby for bundle dependencies
-with-ros ? false,
-rclcpp ? null, nav-msgs ? null, sensor-msgs ? null, tf2-ros ? null, rosbag2 ? null, mc-rtc-msgs ? null,
-useLocal ? false, localWorkspace ? null
+{
+  lib,
+  buildRosPackage,
+  stdenv,
+  fetchgit,
+  cmake,
+  pkg-config,
+  tasks,
+  tvm,
+  eigen-quadprog,
+  libtool,
+  geos,
+  spdlog,
+  ndcurves,
+  mc-rtc-data,
+  state-observation,
+  nanomsg,
+  libnotify,
+  rapidjson,
+  boost,
+  mesh-sampling,
+  python313Packages,
+  qt5,
+  eigen-fmt,
+  doxygen,
+  bundler, # Ruby for bundle dependencies
+  with-ros ? false,
+  rclcpp ? null,
+  nav-msgs ? null,
+  sensor-msgs ? null,
+  tf2-ros ? null,
+  rosbag2 ? null,
+  mc-rtc-msgs ? null,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
 let
-  common = import ./mc-rtc-common.nix { inherit useLocal localWorkspace fetchgit lib; };
+  common = import ./mc-rtc-common.nix {
+    inherit
+      useLocal
+      localWorkspace
+      fetchgit
+      ;
+  };
 in
 
 (if with-ros then buildRosPackage else stdenv.mkDerivation) {
   pname = "mc-rtc";
   inherit (common) version src;
 
-  postPatch = if with-ros then
-    ''
-      sed -i 's@set(''${PACKAGE_PATH_VAR} "''${''${PACKAGE}_INSTALL_PREFIX}@\0/share/''${PACKAGE}@' CMakeLists.txt
-    ''
+  postPatch =
+    if with-ros then
+      ''
+        sed -i 's@set(''${PACKAGE_PATH_VAR} "''${''${PACKAGE}_INSTALL_PREFIX}@\0/share/''${PACKAGE}@' CMakeLists.txt
+      ''
     else
-    "";
+      "";
 
-    nativeBuildInputs = [ cmake qt5.wrapQtAppsHook ];
-  propagatedBuildInputs = [ pkg-config tasks eigen-quadprog libtool geos spdlog ndcurves mc-rtc-data state-observation nanomsg tvm libnotify rapidjson boost mesh-sampling eigen-fmt ]
-  ++ [ python313Packages.gitpython python313Packages.pyqt5 python313Packages.matplotlib]
-  ++ [ doxygen bundler ] # for documentation
-    ++ lib.optional (with-ros && rclcpp != null) rclcpp
-    ++ lib.optional (with-ros && nav-msgs != null) nav-msgs
-    ++ lib.optional (with-ros && sensor-msgs != null) sensor-msgs
-    ++ lib.optional (with-ros && tf2-ros != null) tf2-ros
-    ++ lib.optional (with-ros && rosbag2 != null) rosbag2
-    ++ lib.optional (with-ros && mc-rtc-msgs != null) mc-rtc-msgs;
+  nativeBuildInputs = [
+    cmake
+    qt5.wrapQtAppsHook
+  ];
+  propagatedBuildInputs = [
+    pkg-config
+    tasks
+    eigen-quadprog
+    libtool
+    geos
+    spdlog
+    ndcurves
+    mc-rtc-data
+    state-observation
+    nanomsg
+    tvm
+    libnotify
+    rapidjson
+    boost
+    mesh-sampling
+    eigen-fmt
+  ]
+  ++ [
+    python313Packages.gitpython
+    python313Packages.pyqt5
+    python313Packages.matplotlib
+  ]
+  ++ [
+    doxygen
+    bundler
+  ] # for documentation
+  ++ lib.optional (with-ros && rclcpp != null) rclcpp
+  ++ lib.optional (with-ros && nav-msgs != null) nav-msgs
+  ++ lib.optional (with-ros && sensor-msgs != null) sensor-msgs
+  ++ lib.optional (with-ros && tf2-ros != null) tf2-ros
+  ++ lib.optional (with-ros && rosbag2 != null) rosbag2
+  ++ lib.optional (with-ros && mc-rtc-msgs != null) mc-rtc-msgs;
 
-    preConfigure = ''
-      export ROS_VERSION=2
-    '';
+  preConfigure = ''
+    export ROS_VERSION=2
+  '';
 
   cmakeFlags = [
     "-DBUILD_MC_RTC_PYTHON_UTILS=ON"
@@ -59,8 +119,8 @@ in
 
   meta = with lib; {
     description = "An interface for simulated and real robotic systems suitable for real-time control";
-    homepage    = "https://github.com/jrl-umi3218/mc_rtc";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/mc_rtc";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc/observers/mc-state-observation/default.nix
+++ b/pkgs/mc-rtc/observers/mc-state-observation/default.nix
@@ -1,20 +1,31 @@
-{ stdenv, lib, fetchurl, cmake, mc-rtc, useLocal ? false, localWorkspace ? null, with-ros ? false } :
+{
+  stdenv,
+  lib,
+  fetchurl,
+  cmake,
+  mc-rtc,
+  useLocal ? false,
+  localWorkspace ? null,
+  with-ros ? false,
+}:
 
 stdenv.mkDerivation rec {
   pname = "mc-state-observation";
   version = "1.1.0";
 
-  src = if useLocal then
-    builtins.trace "Using local workspace for ${pname}: ${localWorkspace}/mc_state_obeservation"
-    (builtins.path {
-      path = "${localWorkspace}/mc_state_observation";
-      name = "mc_state_observation-src";
-    })
-  else
-    fetchurl {
-      url = "https://github.com/jrl-umi3218/mc_state_observation/releases/download/v${version}/mc_state_observation-v${version}.tar.gz";
-      sha256 = "sha256-F1LzhAK0MQM4mc5+dr0lK364J7f0nA1ZBe1RZlG3Pmo=";
-    };
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for ${pname}: ${localWorkspace}/mc_state_obeservation" (
+        builtins.path {
+          path = "${localWorkspace}/mc_state_observation";
+          name = "mc_state_observation-src";
+        }
+      )
+    else
+      fetchurl {
+        url = "https://github.com/jrl-umi3218/mc_state_observation/releases/download/v${version}/mc_state_observation-v${version}.tar.gz";
+        sha256 = "sha256-F1LzhAK0MQM4mc5+dr0lK364J7f0nA1ZBe1RZlG3Pmo=";
+      };
 
   nativeBuildInputs = [ cmake ];
   propagatedBuildInputs = [ mc-rtc ];
@@ -40,8 +51,8 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Extra mc_rtc observers";
-    homepage    = "https://github.com/jrl-umi3218/mc_state_observation";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/mc_state_observation";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc/plugins/mc-force-shoe-plugin.nix
+++ b/pkgs/mc-rtc/plugins/mc-force-shoe-plugin.nix
@@ -1,19 +1,31 @@
-{ stdenv, lib, fetchFromGitHub,
-cmake, mc-rtc,
-socat, picocom, screen, minicom,
-useLocal ? false, localWorkspace ? null
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  mc-rtc,
+  socat,
+  picocom,
+  screen,
+  minicom,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mc-force-shoe-plugin";
   version = "2.0.0";
 
-  src = if useLocal then
-      builtins.trace "Using local workspace for mc-force-shoe-plugin: ${localWorkspace}/mc_force_shoe_plugin"
-      (builtins.path {
-        path = "${localWorkspace}/mc_force_shoe_plugin";
-        name = "mc-force-shoe-plugin-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace
+        "Using local workspace for mc-force-shoe-plugin: ${localWorkspace}/mc_force_shoe_plugin"
+        (
+          builtins.path {
+            path = "${localWorkspace}/mc_force_shoe_plugin";
+            name = "mc-force-shoe-plugin-src";
+          }
+        )
     else
       # TODO: ask Hugo to transfer it to jrl-umi3218
       fetchFromGitHub {
@@ -24,11 +36,13 @@ stdenv.mkDerivation (finalAttrs: {
       };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs =
-    [
-      mc-rtc
-      socat picocom screen minicom # make serial communication debugging tools available
-    ];
+  propagatedBuildInputs = [
+    mc-rtc
+    socat
+    picocom
+    screen
+    minicom # make serial communication debugging tools available
+  ];
 
   cmakeFlags = [
     "-DMC_RTC_HONOR_INSTALL_PREFIX=ON"
@@ -38,8 +52,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Plugin to read XSens Force Shoe sensors";
-    homepage    = "https://github.com/Hugo-L3174/mc_force_shoe_plugin";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/Hugo-L3174/mc_force_shoe_plugin";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/mc-rtc/plugins/mc-robot-model-update.nix
+++ b/pkgs/mc-rtc/plugins/mc-robot-model-update.nix
@@ -1,18 +1,27 @@
-{ stdenv, lib, fetchFromGitHub,
-cmake, mc-rtc,
-useLocal ? false, localWorkspace ? null
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  mc-rtc,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (_finalAttrs: {
   pname = "mc-robot-model-update";
   version = "2.0.0";
 
-  src = if useLocal then
-      builtins.trace "Using local workspace for mc-robot-model-update: ${localWorkspace}/mc_robot_model_update"
-      (builtins.path {
-        path = "${localWorkspace}/mc_robot_model_update";
-        name = "mc-robot-model-update-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace
+        "Using local workspace for mc-robot-model-update: ${localWorkspace}/mc_robot_model_update"
+        (
+          builtins.path {
+            path = "${localWorkspace}/mc_robot_model_update";
+            name = "mc-robot-model-update-src";
+          }
+        )
     else
       fetchFromGitHub {
         owner = "jrl-umi3218";
@@ -24,10 +33,9 @@ stdenv.mkDerivation (finalAttrs: {
       };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs =
-    [
-      mc-rtc
-    ];
+  propagatedBuildInputs = [
+    mc-rtc
+  ];
 
   cmakeFlags = [
     "-DMC_RTC_HONOR_INSTALL_PREFIX=ON"
@@ -37,8 +45,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Plugin to update some parameters of a robot model live or from configuration ";
-    homepage    = "https://github.com/jrl-umi3218/mc_robot_model_update";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/mc_robot_model_update";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/mc-rtc/robots/descriptions/g1-description.nix
+++ b/pkgs/mc-rtc/robots/descriptions/g1-description.nix
@@ -1,4 +1,14 @@
-{ stdenv, lib, fetchFromGitHub, cmake, with-ros ? false, ament-cmake, buildRosPackage, useLocal ? false, localWorkspace ? null }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  with-ros ? false,
+  ament-cmake,
+  buildRosPackage,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 (if with-ros then buildRosPackage else stdenv.mkDerivation) {
   pname = "g1-description";
@@ -7,11 +17,12 @@
 
   src =
     if useLocal then
-      builtins.trace "Using local workspace for g1-description: ${localWorkspace}/g1_description"
-      (builtins.path {
-        path = "${localWorkspace}/g1_description";
-        name = "g1-description-src";
-      })
+      builtins.trace "Using local workspace for g1-description: ${localWorkspace}/g1_description" (
+        builtins.path {
+          path = "${localWorkspace}/g1_description";
+          name = "g1-description-src";
+        }
+      )
     else
       fetchFromGitHub {
         owner = "isri-aist";
@@ -22,16 +33,13 @@
 
   buildType = "ament_cmake";
   nativeBuildInputs = if with-ros then [ ament-cmake ] else [ cmake ];
-  propagatedBuildInputs = [];
+  propagatedBuildInputs = [ ];
 
   preConfigure = ''
     export ROS_VERSION=2
   '';
 
-  cmakeFlags = 
-  lib.optional (!with-ros) "-DDISABLE_ROS=ON"
-  ++
-  [
+  cmakeFlags = lib.optional (!with-ros) "-DDISABLE_ROS=ON" ++ [
     "-DBUILD_TESTING=OFF"
   ];
 
@@ -39,9 +47,8 @@
 
   meta = with lib; {
     description = "g1 urdf and data";
-    homepage    = "https://github.com/isri-aist/g1_description";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/isri-aist/g1_description";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }
-

--- a/pkgs/mc-rtc/robots/descriptions/h1-description.nix
+++ b/pkgs/mc-rtc/robots/descriptions/h1-description.nix
@@ -1,4 +1,14 @@
-{ stdenv, lib, fetchFromGitHub, cmake, with-ros ? false, ament-cmake, buildRosPackage, useLocal ? false, localWorkspace ? null }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  with-ros ? false,
+  ament-cmake,
+  buildRosPackage,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 (if with-ros then buildRosPackage else stdenv.mkDerivation) {
   pname = "h1-description";
@@ -7,11 +17,12 @@
 
   src =
     if useLocal then
-      builtins.trace "Using local workspace for h1-description: ${localWorkspace}/h1_description"
-      (builtins.path {
-        path = "${localWorkspace}/h1_description";
-        name = "h1-description-src";
-      })
+      builtins.trace "Using local workspace for h1-description: ${localWorkspace}/h1_description" (
+        builtins.path {
+          path = "${localWorkspace}/h1_description";
+          name = "h1-description-src";
+        }
+      )
     else
       fetchFromGitHub {
         owner = "isri-aist";
@@ -22,16 +33,13 @@
 
   buildType = "ament_cmake";
   nativeBuildInputs = if with-ros then [ ament-cmake ] else [ cmake ];
-  propagatedBuildInputs = [];
+  propagatedBuildInputs = [ ];
 
   preConfigure = ''
     export ROS_VERSION=2
   '';
 
-  cmakeFlags = 
-  lib.optional (!with-ros) "-DDISABLE_ROS=ON"
-  ++
-  [
+  cmakeFlags = lib.optional (!with-ros) "-DDISABLE_ROS=ON" ++ [
     "-DBUILD_TESTING=OFF"
   ];
 
@@ -39,9 +47,8 @@
 
   meta = with lib; {
     description = "h1 urdf and data";
-    homepage    = "https://github.com/isri-aist/h1_description";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/isri-aist/h1_description";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }
-

--- a/pkgs/mc-rtc/robots/descriptions/hrp2-description.nix
+++ b/pkgs/mc-rtc/robots/descriptions/hrp2-description.nix
@@ -1,4 +1,13 @@
-{ stdenv, lib, fetchgit, cmake, with-ros ? false, ament-cmake, buildRosPackage, useLocal ? false, localWorkspace ? null }:
+{
+  stdenv,
+  lib,
+  cmake,
+  with-ros ? false,
+  ament-cmake,
+  buildRosPackage,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 (if with-ros then buildRosPackage else stdenv.mkDerivation) {
   pname = "hrp2-description";
@@ -6,12 +15,15 @@
   separateDebugInfo = false;
 
   # TODO: release hrp2_drc_descriptioin
-  src = if useLocal then
+  src =
+    if useLocal then
       builtins.trace "Using local workspace for hrp2-description: ${localWorkspace}/hrp2_drc_description"
-      (builtins.path {
-        path = "${localWorkspace}/hrp2_drc_description";
-        name = "hrp2-drc-description-src";
-      })
+        (
+          builtins.path {
+            path = "${localWorkspace}/hrp2_drc_description";
+            name = "hrp2-drc-description-src";
+          }
+        )
     else
       builtins.fetchGit {
         url = "git@github.com:isri-aist/hrp2_drc_description.git";
@@ -26,10 +38,7 @@
     export ROS_VERSION=2
   '';
 
-  cmakeFlags = 
-  lib.optional (!with-ros) "-DDISABLE_ROS=ON"
-  ++
-  [
+  cmakeFlags = lib.optional (!with-ros) "-DDISABLE_ROS=ON" ++ [
     "-DBUILD_TESTING=OFF"
     "-DPYTHON_BINDING=OFF"
     "-DINSTALL_DOCUMENTATION=OFF"
@@ -39,9 +48,8 @@
 
   meta = with lib; {
     description = "HRP2 urdf and data";
-    homepage    = "https://gite.lirmm.fr/mc-hrp2/hrp2_drc";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://gite.lirmm.fr/mc-hrp2/hrp2_drc";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }
-

--- a/pkgs/mc-rtc/robots/descriptions/hrp4-description.nix
+++ b/pkgs/mc-rtc/robots/descriptions/hrp4-description.nix
@@ -1,4 +1,11 @@
-{ stdenv, lib, cmake, with-ros ? false, ament-cmake, buildRosPackage }:
+{
+  stdenv,
+  lib,
+  cmake,
+  with-ros ? false,
+  ament-cmake,
+  buildRosPackage,
+}:
 
 (if with-ros then buildRosPackage else stdenv.mkDerivation) {
   pname = "hrp4-description";
@@ -13,16 +20,13 @@
 
   buildType = "ament_cmake";
   nativeBuildInputs = if with-ros then [ ament-cmake ] else [ cmake ];
-  propagatedBuildInputs = [];
+  propagatedBuildInputs = [ ];
 
   preConfigure = ''
     export ROS_VERSION=2
   '';
 
-  cmakeFlags = 
-  lib.optional (!with-ros) "-DDISABLE_ROS=ON"
-  ++
-  [
+  cmakeFlags = lib.optional (!with-ros) "-DDISABLE_ROS=ON" ++ [
     "-DBUILD_TESTING=OFF"
   ];
 
@@ -30,9 +34,8 @@
 
   meta = with lib; {
     description = "HRP4 urdf and data";
-    homepage    = "https://github.com/isri-aist/hrp4_description";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/isri-aist/hrp4_description";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }
-

--- a/pkgs/mc-rtc/robots/descriptions/hrp5-p-description.nix
+++ b/pkgs/mc-rtc/robots/descriptions/hrp5-p-description.nix
@@ -1,4 +1,11 @@
-{ stdenv, lib, cmake, with-ros ? false, ament-cmake, buildRosPackage }:
+{
+  stdenv,
+  lib,
+  cmake,
+  with-ros ? false,
+  ament-cmake,
+  buildRosPackage,
+}:
 
 (if with-ros then buildRosPackage else stdenv.mkDerivation) {
   pname = "hrp5-p-description";
@@ -12,7 +19,7 @@
 
   buildType = "ament_cmake";
   nativeBuildInputs = if with-ros then [ ament-cmake ] else [ cmake ];
-  propagatedBuildInputs = [];
+  propagatedBuildInputs = [ ];
 
   preConfigure = ''
     export ROS_VERSION=2
@@ -26,9 +33,8 @@
 
   meta = with lib; {
     description = "HRP5P urdf and data";
-    homepage    = "https://github.com/isri-aist/hrp5_p_description";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/isri-aist/hrp5_p_description";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }
-

--- a/pkgs/mc-rtc/robots/descriptions/rhps1-description.nix
+++ b/pkgs/mc-rtc/robots/descriptions/rhps1-description.nix
@@ -1,4 +1,13 @@
-{ stdenv, lib, fetchgit, cmake, with-ros ? false, ament-cmake, buildRosPackage, useLocal ? false, localWorkspace ? null }:
+{
+  stdenv,
+  lib,
+  cmake,
+  with-ros ? false,
+  ament-cmake,
+  buildRosPackage,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 (if with-ros then buildRosPackage else stdenv.mkDerivation) {
   pname = "rhps1-description";
@@ -7,11 +16,12 @@
 
   src =
     if useLocal then
-      builtins.trace "Using local workspace for rhps1-description: ${localWorkspace}/rhps1_description"
-      (builtins.path {
-        path = "${localWorkspace}/rhps1_description";
-        name = "rhps1-description-src";
-      })
+      builtins.trace "Using local workspace for rhps1-description: ${localWorkspace}/rhps1_description" (
+        builtins.path {
+          path = "${localWorkspace}/rhps1_description";
+          name = "rhps1-description-src";
+        }
+      )
     else
       builtins.fetchGit {
         url = "git@github.com:isri-aist/rhps1_description";
@@ -26,10 +36,7 @@
     export ROS_VERSION=2
   '';
 
-  cmakeFlags = 
-  lib.optional (!with-ros) "-DDISABLE_ROS=ON"
-  ++
-  [
+  cmakeFlags = lib.optional (!with-ros) "-DDISABLE_ROS=ON" ++ [
     "-DBUILD_TESTING=OFF"
     "-DPYTHON_BINDING=OFF"
     "-DINSTALL_DOCUMENTATION=OFF"
@@ -39,9 +46,8 @@
 
   meta = with lib; {
     description = "rhps1 urdf and data";
-    homepage    = "https://github.com/isri-aist/mc_rhps1";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/isri-aist/mc_rhps1";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }
-

--- a/pkgs/mc-rtc/robots/descriptions/ur-description.nix
+++ b/pkgs/mc-rtc/robots/descriptions/ur-description.nix
@@ -1,4 +1,12 @@
-{ stdenv, lib, fetchFromGitHub, cmake, with-ros ? false, ament-cmake, buildRosPackage, useLocal ? false, localWorkspace ? null, xacro }:
+{
+  lib,
+  fetchFromGitHub,
+  ament-cmake,
+  buildRosPackage,
+  useLocal ? false,
+  localWorkspace ? null,
+  xacro,
+}:
 
 buildRosPackage {
   pname = "ur-description";
@@ -7,11 +15,12 @@ buildRosPackage {
 
   src =
     if useLocal then
-      builtins.trace "Using local workspace for ur-description: ${localWorkspace}/ur_description"
-      (builtins.path {
-        path = "${localWorkspace}/ur_description";
-        name = "ur-description-src";
-      })
+      builtins.trace "Using local workspace for ur-description: ${localWorkspace}/ur_description" (
+        builtins.path {
+          path = "${localWorkspace}/ur_description";
+          name = "ur-description-src";
+        }
+      )
     else
       fetchFromGitHub {
         owner = "UniversalRobots";
@@ -23,7 +32,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   nativeBuildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [xacro];
+  propagatedBuildInputs = [ xacro ];
 
   preConfigure = ''
     export ROS_VERSION=2
@@ -33,9 +42,8 @@ buildRosPackage {
 
   meta = with lib; {
     description = "ur robot urdf and data";
-    homepage    = "https://github.com/isri-aist/mc_ur_description";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/isri-aist/mc_ur_description";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }
-

--- a/pkgs/mc-rtc/robots/descriptions/ur5e-description.nix
+++ b/pkgs/mc-rtc/robots/descriptions/ur5e-description.nix
@@ -1,7 +1,16 @@
-{ stdenv, lib, fetchFromGitHub, cmake, 
-with-ros ? true, ament-cmake, buildRosPackage, xacro,
-ur-description,
-useLocal ? false, localWorkspace ? null, }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  with-ros ? true,
+  ament-cmake,
+  buildRosPackage,
+  xacro,
+  ur-description,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 (if with-ros then buildRosPackage else stdenv.mkDerivation) {
   pname = "ur5e-description";
@@ -10,11 +19,12 @@ useLocal ? false, localWorkspace ? null, }:
 
   src =
     if useLocal then
-      builtins.trace "Using local workspace for ur5e-description: ${localWorkspace}/mc_ur5e_description"
-      (builtins.path {
-        path = "${localWorkspace}/mc_ur5e_description";
-        name = "ur5e-description-src";
-      })
+      builtins.trace "Using local workspace for ur5e-description: ${localWorkspace}/mc_ur5e_description" (
+        builtins.path {
+          path = "${localWorkspace}/mc_ur5e_description";
+          name = "ur5e-description-src";
+        }
+      )
     else
       fetchFromGitHub {
         owner = "isri-aist";
@@ -25,17 +35,13 @@ useLocal ? false, localWorkspace ? null, }:
 
   buildType = "ament_cmake";
   nativeBuildInputs = if with-ros then [ ament-cmake ] else [ cmake ];
-  propagatedBuildInputs = [ ur-description ]
-   ++ lib.optionals with-ros [ xacro ];
+  propagatedBuildInputs = [ ur-description ] ++ lib.optionals with-ros [ xacro ];
 
   preConfigure = ''
     export ROS_VERSION=2
   '';
 
-  cmakeFlags = 
-  lib.optional (!with-ros) "-DDISABLE_ROS=ON"
-  ++
-  [
+  cmakeFlags = lib.optional (!with-ros) "-DDISABLE_ROS=ON" ++ [
     "-DBUILD_TESTING=OFF"
   ];
 
@@ -43,9 +49,8 @@ useLocal ? false, localWorkspace ? null, }:
 
   meta = with lib; {
     description = "UR5e robot urdf and data";
-    homepage    = "https://github.com/isri-aist/mc_ur5e_description";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/isri-aist/mc_ur5e_description";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }
-

--- a/pkgs/mc-rtc/robots/mc-panda/default.nix
+++ b/pkgs/mc-rtc/robots/mc-panda/default.nix
@@ -1,18 +1,29 @@
-{ stdenv, lib, fetchFromGitHub, fetchgit, 
-cmake, mc-rtc, libfranka, franka-description, xacro,
-useLocal ? false, localWorkspace ? null,
-with-ros ? false } :
+{
+  stdenv,
+  lib,
+  fetchgit,
+  cmake,
+  mc-rtc,
+  libfranka,
+  franka-description,
+  xacro,
+  useLocal ? false,
+  localWorkspace ? null,
+  with-ros ? false,
+}:
 
 stdenv.mkDerivation {
   pname = "mc-panda";
   version = "1.0.0";
 
-  src = if useLocal then
-      builtins.trace "Using local workspace for mc-panda: ${localWorkspace}/mc_panda"
-      (builtins.path {
-        path = "${localWorkspace}/mc_panda";
-        name = "mc-panda-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for mc-panda: ${localWorkspace}/mc_panda" (
+        builtins.path {
+          path = "${localWorkspace}/mc_panda";
+          name = "mc-panda-src";
+        }
+      )
     else
       # TODO: release mc-panda
       fetchgit {
@@ -23,11 +34,16 @@ stdenv.mkDerivation {
       };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs =
-    builtins.trace "panda with-ros: ${toString with-ros}"
-    (
-    [ mc-rtc libfranka ]
-    ++ lib.optional (with-ros) [franka-description xacro]);
+  propagatedBuildInputs = builtins.trace "panda with-ros: ${toString with-ros}" (
+    [
+      mc-rtc
+      libfranka
+    ]
+    ++ lib.optional (with-ros) [
+      franka-description
+      xacro
+    ]
+  );
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -40,8 +56,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Panda RobotModule for mc-rtc";
-    homepage    = "https://github.com/jrl-umi3218/mc_panda";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/mc_panda";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc/robots/mc-panda/franka-description.nix
+++ b/pkgs/mc-rtc/robots/mc-panda/franka-description.nix
@@ -1,40 +1,50 @@
 # FIXME: unused
 # See https://github.com/frankarobotics/franka_description to see how to generate the URDF models from xacro
 # We would need to compile, install them, then modify mc-panda to use them. wtf frankarobotics.
-{ lib
-, buildRosPackage, ament-cmake
-, fetchFromGitHub, libfranka
-, xacro
-, useLocal ? false, localWorkspace ? null
+{
+  lib,
+  buildRosPackage,
+  ament-cmake,
+  fetchFromGitHub,
+  libfranka,
+  xacro,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
 buildRosPackage {
   pname = "franka_description";
   version = "2.6.0";
 
-  src = if useLocal then
-    builtins.trace "Using local workspace for franka_description: ${localWorkspace}/franka_description"
-    (builtins.path {
-      path = "${localWorkspace}/franka_description";
-      name = "franka_description-src";
-    })
-  else
-    fetchFromGitHub {
-      owner = "frankarobotics";
-      repo = "franka_description";
-      rev = "2.6.0"; # tag name
-      sha256 = "sha256-+5IqH80KWvUb7aoHh9n0CIod5zh3q3pRQaWi62Ed8aY=";
-    };
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for franka_description: ${localWorkspace}/franka_description"
+        (
+          builtins.path {
+            path = "${localWorkspace}/franka_description";
+            name = "franka_description-src";
+          }
+        )
+    else
+      fetchFromGitHub {
+        owner = "frankarobotics";
+        repo = "franka_description";
+        rev = "2.6.0"; # tag name
+        sha256 = "sha256-+5IqH80KWvUb7aoHh9n0CIod5zh3q3pRQaWi62Ed8aY=";
+      };
 
   buildType = "ament_cmake";
-  nativeBuildInputs = [ ament-cmake xacro ];
+  nativeBuildInputs = [
+    ament-cmake
+    xacro
+  ];
   propagatedBuildInputs = [ libfranka ];
 
   meta = {
     description = "URDF, meshes, and other description files for Franka robots";
-    homepage    = "https://github.com/frankarobotics/franka_description";
-    license     = lib.licenses.asl20;
-    platforms   = lib.platforms.linux;
+    homepage = "https://github.com/frankarobotics/franka_description";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
     maintainers = [ ];
   };
 }

--- a/pkgs/mc-rtc/robots/mc-panda/libfranka.nix
+++ b/pkgs/mc-rtc/robots/mc-panda/libfranka.nix
@@ -1,30 +1,50 @@
-{ stdenv, lib, fetchgit, cmake, pkg-config
-, eigen, poco, tinyxml-2
-# , doxygen, graphviz
-, useLocal ? false, localWorkspace ? null
+{
+  stdenv,
+  lib,
+  fetchgit,
+  cmake,
+  pkg-config,
+  eigen,
+  poco,
+  tinyxml-2,
+  # , doxygen, graphviz
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
 stdenv.mkDerivation {
   pname = "libfranka";
   version = "0.9.2";
 
-  src = if useLocal then
-    builtins.trace "Using local workspace for libfranka: ${localWorkspace}/libfranka"
-    (builtins.path {
-      path = "${localWorkspace}/libfranka";
-      name = "libfranka-src";
-    })
-  else
-    fetchgit {
-      url = "https://github.com/frankarobotics/libfranka";
-      rev = "f3b8d775a9c847cab32684c8a316f67867761674";
-      sha256 = "sha256-xPzzJ4YlRz7MVRgcZaV3QhlOrUFlajJLaArchBylCQM=";
-      fetchSubmodules = true;
-    };
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for libfranka: ${localWorkspace}/libfranka" (
+        builtins.path {
+          path = "${localWorkspace}/libfranka";
+          name = "libfranka-src";
+        }
+      )
+    else
+      fetchgit {
+        url = "https://github.com/frankarobotics/libfranka";
+        rev = "f3b8d775a9c847cab32684c8a316f67867761674";
+        sha256 = "sha256-xPzzJ4YlRz7MVRgcZaV3QhlOrUFlajJLaArchBylCQM=";
+        fetchSubmodules = true;
+      };
 
-  nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ eigen poco tinyxml-2 ];
-  propagatedBuildInputs = [ poco tinyxml-2 ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+  buildInputs = [
+    eigen
+    poco
+    tinyxml-2
+  ];
+  propagatedBuildInputs = [
+    poco
+    tinyxml-2
+  ];
 
   # Optional: enable documentation if you want
   # nativeBuildInputs = nativeBuildInputs ++ [ doxygen graphviz ];
@@ -44,9 +64,9 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "C++ library for Franka Robotics research robots";
-    homepage    = "https://github.com/frankarobotics/libfranka";
-    license     = licenses.asl20;
-    platforms   = platforms.linux;
+    homepage = "https://github.com/frankarobotics/libfranka";
+    license = licenses.asl20;
+    platforms = platforms.linux;
     maintainers = [ ];
   };
 }

--- a/pkgs/mc-rtc/robots/mc-panda/libpoco.nix
+++ b/pkgs/mc-rtc/robots/mc-panda/libpoco.nix
@@ -1,4 +1,14 @@
-{ stdenv, lib, fetchFromGitHub, cmake, pkg-config, openssl_1_1, zlib, pcre, expat }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  openssl_1_1,
+  zlib,
+  pcre,
+  expat,
+}:
 
 stdenv.mkDerivation rec {
   pname = "poco";
@@ -11,8 +21,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-60XBC2cAX/v33cNh9JRvhDXpMTSeVDN6dvFGYawrQpE=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ openssl_1_1 zlib pcre expat ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+  buildInputs = [
+    openssl_1_1
+    zlib
+    pcre
+    expat
+  ];
 
   cmakeFlags = [
     "-DENABLE_TESTS=OFF"
@@ -47,6 +65,6 @@ stdenv.mkDerivation rec {
     homepage = "https://pocoproject.org/";
     license = licenses.boost;
     platforms = platforms.unix;
-    maintainers = [];
+    maintainers = [ ];
   };
 }

--- a/pkgs/mc-rtc/robots/mc-panda/mc-franka.nix
+++ b/pkgs/mc-rtc/robots/mc-panda/mc-franka.nix
@@ -1,19 +1,29 @@
-{ stdenv, lib, fetchgit, 
-cmake, mc-rtc, libfranka, mc-panda,
-sudo, libcap,
-useLocal ? false, localWorkspace ? null,
-} :
+{
+  stdenv,
+  lib,
+  fetchgit,
+  cmake,
+  mc-rtc,
+  libfranka,
+  mc-panda,
+  sudo,
+  libcap,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 stdenv.mkDerivation {
   pname = "mc-franka";
   version = "1.0.0";
 
-  src = if useLocal then
-      builtins.trace "Using local workspace for mc-franka: ${localWorkspace}/mc_franka"
-      (builtins.path {
-        path = "${localWorkspace}/mc_franka";
-        name = "mc-franka-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for mc-franka: ${localWorkspace}/mc_franka" (
+        builtins.path {
+          path = "${localWorkspace}/mc_franka";
+          name = "mc-franka-src";
+        }
+      )
     else
       # TODO: release mc-franka
       fetchgit {
@@ -23,8 +33,16 @@ stdenv.mkDerivation {
         sha256 = "sha256-CXh2wCVIC3FxZ+bBmHXNGXYGqiqFStITFj9NRgGT5EU=";
       };
 
-  nativeBuildInputs = [ cmake sudo libcap ];
-  propagatedBuildInputs = [ mc-rtc libfranka mc-panda ];
+  nativeBuildInputs = [
+    cmake
+    sudo
+    libcap
+  ];
+  propagatedBuildInputs = [
+    mc-rtc
+    libfranka
+    mc-panda
+  ];
 
   cmakeFlags = [
     "-DUSE_REALTIME=OFF"
@@ -37,8 +55,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Interface between libfranka and mc_rtc";
-    homepage    = "https://github.com/jrl-umi3218/mc_franka";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/mc_franka";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc/robots/mc-panda/mc-panda-lirmm.nix
+++ b/pkgs/mc-rtc/robots/mc-panda/mc-panda-lirmm.nix
@@ -1,7 +1,11 @@
-{ stdenv, lib, fetchgit, 
-mc-panda,
-cmake,
-useLocal ? false, localWorkspace ? null
+{
+  stdenv,
+  lib,
+  fetchgit,
+  mc-panda,
+  cmake,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
 let
@@ -12,12 +16,14 @@ stdenv.mkDerivation {
   pname = "mc-panda-lirmm";
   version = "${version}";
 
-  src = if useLocal then
-      builtins.trace "Using local workspace for mc-panda: ${localWorkspace}/${localFolder}"
-      (builtins.path {
-        path = "${localWorkspace}/${localFolder}";
-        name = "mc-panda-lirmm-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for mc-panda: ${localWorkspace}/${localFolder}" (
+        builtins.path {
+          path = "${localWorkspace}/${localFolder}";
+          name = "mc-panda-lirmm-src";
+        }
+      )
     else
       # TODO: release mc-panda-lirmm
       fetchgit {
@@ -41,8 +47,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Panda RobotModule specialization for LIRMM robots for mc-rtc";
-    homepage    = "https://github.com/jrl-umi3218/mc_panda_lirmm";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/mc_panda_lirmm";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc/robots/modules/mc-g1.nix
+++ b/pkgs/mc-rtc/robots/modules/mc-g1.nix
@@ -1,10 +1,17 @@
-{ stdenv, lib, fetchFromGitHub, cmake, mc-rtc, g1-description } :
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  mc-rtc,
+  g1-description,
+}:
 
 let
 
-g1-description' = g1-description.override {
-  with-ros = mc-rtc.with-ros;
-};
+  g1-description' = g1-description.override {
+    with-ros = mc-rtc.with-ros;
+  };
 
 in
 
@@ -12,16 +19,18 @@ stdenv.mkDerivation {
   pname = "mc-g1";
   version = "1.0.0";
 
-  src = 
-    fetchFromGitHub {
-      owner = "isri-aist";
-      repo = "mc_g1";
-      rev = "d30edab21f5ec00ef737e55d56ba5e2afc89460e";
-      hash = "sha256-Ispz48omVbcgCpCHwZ3XhUF0UcCc2hQllprGGB0O01Y=";
-    };
+  src = fetchFromGitHub {
+    owner = "isri-aist";
+    repo = "mc_g1";
+    rev = "d30edab21f5ec00ef737e55d56ba5e2afc89460e";
+    hash = "sha256-Ispz48omVbcgCpCHwZ3XhUF0UcCc2hQllprGGB0O01Y=";
+  };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ g1-description' mc-rtc ];
+  propagatedBuildInputs = [
+    g1-description'
+    mc-rtc
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -31,8 +40,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "g1 RobotModule for mc-rtc";
-    homepage    = "https://github.com/isri-aist/mc_g1";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/isri-aist/mc_g1";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc/robots/modules/mc-h1.nix
+++ b/pkgs/mc-rtc/robots/modules/mc-h1.nix
@@ -1,10 +1,17 @@
-{ stdenv, lib, fetchFromGitHub, cmake, mc-rtc, h1-description } :
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  mc-rtc,
+  h1-description,
+}:
 
 let
 
-h1-description' = h1-description.override {
-  with-ros = mc-rtc.with-ros;
-};
+  h1-description' = h1-description.override {
+    with-ros = mc-rtc.with-ros;
+  };
 
 in
 
@@ -12,16 +19,18 @@ stdenv.mkDerivation {
   pname = "mc-h1";
   version = "1.0.0";
 
-  src = 
-    fetchFromGitHub {
-      owner = "isri-aist";
-      repo = "mc_h1";
-      rev = "e9e5c4b1220d68229600824ad8a34f32b2f76dc0";
-      hash = "sha256-dUf7TLxwJEWsumJrWz497AYfu3WI2zIyN27OvWLE2IQ=";
-    };
+  src = fetchFromGitHub {
+    owner = "isri-aist";
+    repo = "mc_h1";
+    rev = "e9e5c4b1220d68229600824ad8a34f32b2f76dc0";
+    hash = "sha256-dUf7TLxwJEWsumJrWz497AYfu3WI2zIyN27OvWLE2IQ=";
+  };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ h1-description' mc-rtc ];
+  propagatedBuildInputs = [
+    h1-description'
+    mc-rtc
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -31,8 +40,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Unitree H1 RobotModule for mc-rtc";
-    homepage    = "https://github.com/isri-aist/mc_h1";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/isri-aist/mc_h1";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc/robots/modules/mc-hrp2.nix
+++ b/pkgs/mc-rtc/robots/modules/mc-hrp2.nix
@@ -1,10 +1,18 @@
-{ stdenv, lib, fetchgit, cmake, mc-rtc, hrp2-description, useLocal ? false, localWorkspace ? null } :
+{
+  stdenv,
+  lib,
+  cmake,
+  mc-rtc,
+  hrp2-description,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 let
 
-hrp2-description' = hrp2-description.override {
-  with-ros = mc-rtc.with-ros;
-};
+  hrp2-description' = hrp2-description.override {
+    with-ros = mc-rtc.with-ros;
+  };
 
 in
 
@@ -13,20 +21,25 @@ stdenv.mkDerivation {
   version = "1.0.0";
 
   # TODO: release mc-hrp2
-  src = if useLocal then
-    builtins.trace "Using local workspace for mc-hrp2: ${localWorkspace}/mc-hrp2"
-    (builtins.path {
-      path = "${localWorkspace}/mc-hrp2";
-      name = "mc-hrp2-src";
-    })
-  else
-    builtins.fetchGit {
-      url = "git@github.com:isri-aist/mc-hrp2";
-      rev = "58d64f62e6031571f9fff9b6211f6dcc2d93535b";
-    };
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for mc-hrp2: ${localWorkspace}/mc-hrp2" (
+        builtins.path {
+          path = "${localWorkspace}/mc-hrp2";
+          name = "mc-hrp2-src";
+        }
+      )
+    else
+      builtins.fetchGit {
+        url = "git@github.com:isri-aist/mc-hrp2";
+        rev = "58d64f62e6031571f9fff9b6211f6dcc2d93535b";
+      };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ hrp2-description' mc-rtc ];
+  propagatedBuildInputs = [
+    hrp2-description'
+    mc-rtc
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -39,8 +52,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "HRP2DRC RobotModule for mc-rtc";
-    homepage    = "https://gite.lirmm.fr/mc-hrp2/mc-hrp2";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://gite.lirmm.fr/mc-hrp2/mc-hrp2";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc/robots/modules/mc-hrp4.nix
+++ b/pkgs/mc-rtc/robots/modules/mc-hrp4.nix
@@ -1,12 +1,18 @@
-{ stdenv, lib, cmake, mc-rtc, hrp4-description,
-useLocal ? false, localWorkspace ? null
-} :
+{
+  stdenv,
+  lib,
+  cmake,
+  mc-rtc,
+  hrp4-description,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 let
 
-hrp4-description' = hrp4-description.override {
-  with-ros = mc-rtc.with-ros;
-};
+  hrp4-description' = hrp4-description.override {
+    with-ros = mc-rtc.with-ros;
+  };
 
 in
 
@@ -14,12 +20,14 @@ stdenv.mkDerivation {
   pname = "mc-hrp4";
   version = "1.0.0";
 
-  src = if useLocal then
-      builtins.trace "Using local workspace for mc-hrp4: ${localWorkspace}/mc-hrp4"
-      (builtins.path {
-        path = "${localWorkspace}/mc-hrp4";
-        name = "mc-hrp4-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for mc-hrp4: ${localWorkspace}/mc-hrp4" (
+        builtins.path {
+          path = "${localWorkspace}/mc-hrp4";
+          name = "mc-hrp4-src";
+        }
+      )
     else
       builtins.fetchGit {
         url = "git@github.com:isri-aist/mc-hrp4";
@@ -28,7 +36,10 @@ stdenv.mkDerivation {
       };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ hrp4-description' mc-rtc ];
+  propagatedBuildInputs = [
+    hrp4-description'
+    mc-rtc
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -40,8 +51,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "HRP4 RobotModule for mc-rtc";
-    homepage    = "https://gite.lirmm.fr/mc-hrp4/mc-hrp4";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://gite.lirmm.fr/mc-hrp4/mc-hrp4";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc/robots/modules/mc-hrp5-p.nix
+++ b/pkgs/mc-rtc/robots/modules/mc-hrp5-p.nix
@@ -1,10 +1,16 @@
-{ stdenv, lib, fetchgit, cmake, mc-rtc, hrp5-p-description } :
+{
+  stdenv,
+  lib,
+  cmake,
+  mc-rtc,
+  hrp5-p-description,
+}:
 
 let
 
-hrp5-p-description' = hrp5-p-description.override {
-  with-ros = mc-rtc.with-ros;
-};
+  hrp5-p-description' = hrp5-p-description.override {
+    with-ros = mc-rtc.with-ros;
+  };
 
 in
 
@@ -18,7 +24,10 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ hrp5-p-description' mc-rtc ];
+  propagatedBuildInputs = [
+    hrp5-p-description'
+    mc-rtc
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -30,8 +39,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "HRP5-P RobotModule for mc-rtc";
-    homepage    = "https://gite.lirmm.fr/mc-hrp5/mc-hrp5_p";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://gite.lirmm.fr/mc-hrp5/mc-hrp5_p";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc/robots/modules/mc-rhps1.nix
+++ b/pkgs/mc-rtc/robots/modules/mc-rhps1.nix
@@ -1,25 +1,34 @@
-{ stdenv, lib, cmake, mc-rtc, rhps1-description } :
+{
+  stdenv,
+  lib,
+  cmake,
+  mc-rtc,
+  rhps1-description,
+}:
 
 let
 
-rhps1-description' = rhps1-description.override {
-  with-ros = mc-rtc.with-ros;
-};
+  rhps1-description' = rhps1-description.override {
+    with-ros = mc-rtc.with-ros;
+  };
 
 in
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (_finalAttrs: {
   pname = "mc-rhps1";
   version = "1.0.0";
 
   src = builtins.fetchGit {
-      url = "git@github.com:isri-aist/mc_rhps1";
-      # Release v1.0.0
-      rev = "4e53bc180321b29354fbd1b2f0f3d30dea8df282";
+    url = "git@github.com:isri-aist/mc_rhps1";
+    # Release v1.0.0
+    rev = "4e53bc180321b29354fbd1b2f0f3d30dea8df282";
   };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ rhps1-description' mc-rtc ];
+  propagatedBuildInputs = [
+    rhps1-description'
+    mc-rtc
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -30,8 +39,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "RHPS1 RobotModule for mc-rtc";
-    homepage    = "https://github.com/isri-aist/mc_rhps1";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/isri-aist/mc_rhps1";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 })

--- a/pkgs/mc-rtc/robots/modules/mc-ur5e.nix
+++ b/pkgs/mc-rtc/robots/modules/mc-ur5e.nix
@@ -1,10 +1,17 @@
-{ stdenv, lib, fetchFromGitHub, cmake, mc-rtc, ur5e-description } :
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  mc-rtc,
+  ur5e-description,
+}:
 
 let
 
-ur5e-description' = ur5e-description.override {
-  with-ros = mc-rtc.with-ros;
-};
+  ur5e-description' = ur5e-description.override {
+    with-ros = mc-rtc.with-ros;
+  };
 
 in
 
@@ -12,16 +19,18 @@ stdenv.mkDerivation {
   pname = "mc-ur5e";
   version = "1.0.0";
 
-  src =
-    fetchFromGitHub {
-      owner = "isri-aist";
-      repo = "mc_ur5e";
-      rev = "980e2f0914df67653a261d0aaeb6aa50eb483df9";
-      hash = "sha256-+E0XzvxJonmjAi08UXwh+tZHEkn0Eik+kPMQcmD30dA=";
-    };
+  src = fetchFromGitHub {
+    owner = "isri-aist";
+    repo = "mc_ur5e";
+    rev = "980e2f0914df67653a261d0aaeb6aa50eb483df9";
+    hash = "sha256-+E0XzvxJonmjAi08UXwh+tZHEkn0Eik+kPMQcmD30dA=";
+  };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ ur5e-description' mc-rtc ];
+  propagatedBuildInputs = [
+    ur5e-description'
+    mc-rtc
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -31,8 +40,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "ur5e RobotModule for mc-rtc";
-    homepage    = "https://github.com/isri-aist/mc_ur5e";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/isri-aist/mc_ur5e";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix
+++ b/pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix
@@ -1,44 +1,49 @@
-{ lib
-, buildRosPackage, ament-cmake
-, fetchFromGitHub
-, mc-rtc
-, qt5
-, qwt
-, libGL
-, libGLU
-, rviz2
-, rclcpp
-, visualization-msgs
-, tf2-ros
-, ros2cli
-, ros2launch
-, ros2run
-, useLocal ? false, localWorkspace ? null
+{
+  lib,
+  buildRosPackage,
+  ament-cmake,
+  fetchFromGitHub,
+  mc-rtc,
+  qt5,
+  qwt,
+  libGL,
+  libGLU,
+  rviz2,
+  rclcpp,
+  visualization-msgs,
+  tf2-ros,
+  ros2cli,
+  ros2launch,
+  ros2run,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
 let
   pname = "mc-rtc-rviz-panel";
   version = "1.6.1";
   localSrc = "${localWorkspace}/mc_rtc_ros";
-  fetched =  if useLocal then
-    builtins.trace "Using local workspace for mc-rtc-rviz-panel: ${localSrc}"
-    (builtins.path {
-      path = "${localSrc}";
-      name = "${pname}-src";
-    })
-  else
-    fetchFromGitHub {
-      owner = "jrl-umi3218";
-      repo = "mc_rtc_ros";
-      rev = "d769df946c38f8a5befc2fe790fdba9ac739d566"; # TODO: release mc_rtc_ros
-      sha256 = "sha256-Gmxv/nYKGcK9G1r0i08kLzTc2Dj8qCAQA/S0bic1LKA=";
-    };
-    # fetchFromGitHub {
-    #   owner = "arntanguy";
-    #   repo = "mc_rtc_ros";
-    #   rev = "topic/nix";
-    #   hash = "sha256-Gmxv/nYKGcK9G1r0i08kLzTc2Dj8qCAQA/S0bic1LKA=";
-    # };
+  fetched =
+    if useLocal then
+      builtins.trace "Using local workspace for mc-rtc-rviz-panel: ${localSrc}" (
+        builtins.path {
+          path = "${localSrc}";
+          name = "${pname}-src";
+        }
+      )
+    else
+      fetchFromGitHub {
+        owner = "jrl-umi3218";
+        repo = "mc_rtc_ros";
+        rev = "d769df946c38f8a5befc2fe790fdba9ac739d566"; # TODO: release mc_rtc_ros
+        sha256 = "sha256-Gmxv/nYKGcK9G1r0i08kLzTc2Dj8qCAQA/S0bic1LKA=";
+      };
+  # fetchFromGitHub {
+  #   owner = "arntanguy";
+  #   repo = "mc_rtc_ros";
+  #   rev = "topic/nix";
+  #   hash = "sha256-Gmxv/nYKGcK9G1r0i08kLzTc2Dj8qCAQA/S0bic1LKA=";
+  # };
 in
 buildRosPackage {
   pname = "${pname}";
@@ -70,9 +75,9 @@ buildRosPackage {
 
   meta = {
     description = "Tools for the mc_rtc framework built around ROS (rviz panel, etc)";
-    homepage    = "https://github.com/jrl-umi3218/mc_rtc_ros";
-    license     = lib.licenses.bsd2;
-    platforms   = lib.platforms.linux;
-    maintainers = [];
+    homepage = "https://github.com/jrl-umi3218/mc_rtc_ros";
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.linux;
+    maintainers = [ ];
   };
 }

--- a/pkgs/mc-rtc/ros/mc-rtc-ticker.nix
+++ b/pkgs/mc-rtc/ros/mc-rtc-ticker.nix
@@ -1,39 +1,43 @@
-{ lib
-, buildRosPackage, ament-cmake
-, runtimeShell, writeTextFile
-, fetchFromGitHub
-, mc-rtc-rviz-panel
-, ros2cli
-, ros2launch
-, ros2run
-, ros2topic
-, rviz2
-, useLocal ? false, localWorkspace ? null
+{
+  lib,
+  buildRosPackage,
+  ament-cmake,
+  runtimeShell,
+  fetchFromGitHub,
+  mc-rtc-rviz-panel,
+  ros2cli,
+  ros2launch,
+  ros2run,
+  ros2topic,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
 let
   pname = "mc-rtc-ticker";
   version = "1.6.1";
   localSrc = "${localWorkspace}/mc_rtc_ros";
-  fetched = if useLocal then
-    builtins.trace "Using local workspace for mc-rtc-ticker: ${localSrc}"
-    (builtins.path {
-      path = "${localSrc}";
-      name = "${pname}-src";
-    })
-  else
-    # fetchFromGitHub {
-    #   owner = "jrl-umi3218";
-    #   repo = "mc_rtc_ros";
-    #   rev = "227917d348971b3ba39e7dcef0df4ca65c6bf511";
-    #   sha256 = "sha256-40gtvLRzFi7Rd9BwiX3P/OWqH2fUCuZoUO53zYJdwzc=";
-    # };
-    fetchFromGitHub {
-      owner = "arntanguy";
-      repo = "mc_rtc_ros";
-      rev = "topic/nix";
-      hash = "sha256-Gmxv/nYKGcK9G1r0i08kLzTc2Dj8qCAQA/S0bic1LKA=";
-    };
+  fetched =
+    if useLocal then
+      builtins.trace "Using local workspace for mc-rtc-ticker: ${localSrc}" (
+        builtins.path {
+          path = "${localSrc}";
+          name = "${pname}-src";
+        }
+      )
+    else
+      # fetchFromGitHub {
+      #   owner = "jrl-umi3218";
+      #   repo = "mc_rtc_ros";
+      #   rev = "227917d348971b3ba39e7dcef0df4ca65c6bf511";
+      #   sha256 = "sha256-40gtvLRzFi7Rd9BwiX3P/OWqH2fUCuZoUO53zYJdwzc=";
+      # };
+      fetchFromGitHub {
+        owner = "arntanguy";
+        repo = "mc_rtc_ros";
+        rev = "topic/nix";
+        hash = "sha256-Gmxv/nYKGcK9G1r0i08kLzTc2Dj8qCAQA/S0bic1LKA=";
+      };
 in
 buildRosPackage {
   pname = "${pname}";
@@ -68,9 +72,9 @@ buildRosPackage {
 
   meta = {
     description = "Ticker utility for mc_rtc, installs display.rviz";
-    homepage    = "https://github.com/jrl-umi3218/mc_rtc_ros";
-    license     = lib.licenses.bsd2;
-    platforms   = lib.platforms.linux;
-    maintainers = [];
+    homepage = "https://github.com/jrl-umi3218/mc_rtc_ros";
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.linux;
+    maintainers = [ ];
   };
 }

--- a/pkgs/mc-udp/default.nix
+++ b/pkgs/mc-udp/default.nix
@@ -1,4 +1,10 @@
-{ stdenv, lib, fetchgit, cmake, mc-rtc }:
+{
+  stdenv,
+  lib,
+  fetchgit,
+  cmake,
+  mc-rtc,
+}:
 
 stdenv.mkDerivation {
   pname = "mc-udp";
@@ -6,12 +12,11 @@ stdenv.mkDerivation {
 
   # master branch as of 2025.24.13
   # TODO: do a proper 1.0.0 release
-  src = 
-    fetchgit {
-      url = "https://github.com/jrl-umi3218/mc_udp";
-      rev = "b6be9c9423b6c68a3b375641e99affed448cf825";
-      sha256 = "";
-    };
+  src = fetchgit {
+    url = "https://github.com/jrl-umi3218/mc_udp";
+    rev = "b6be9c9423b6c68a3b375641e99affed448cf825";
+    sha256 = "";
+  };
 
   nativeBuildInputs = [ cmake ];
   propagatedBuildInputs = [ mc-rtc ];
@@ -27,8 +32,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "UDP interface for mc_rtc";
-    homepage    = "https://github.com/jrl-umi3218/mc_udp";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/mc_udp";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/mesh-sampling/default.nix
+++ b/pkgs/mesh-sampling/default.nix
@@ -1,18 +1,29 @@
-{ stdenv, lib, fetchgit, 
-cmake, qhull, assimp, cli11, eigen, libz,
-useLocal ? false, localWorkspace ? null,
-} :
+{
+  stdenv,
+  lib,
+  fetchgit,
+  cmake,
+  qhull,
+  assimp,
+  cli11,
+  eigen,
+  libz,
+  useLocal ? false,
+  localWorkspace ? null,
+}:
 
 stdenv.mkDerivation {
   pname = "mesh-sampling";
   version = "1.0.0";
 
-  src = if useLocal then
-      builtins.trace "Using local workspace for mesh-sampling: ${localWorkspace}/mesh_sampling"
-      (builtins.path {
-        path = "${localWorkspace}/mesh_sampling";
-        name = "mesh-sampling-src";
-      })
+  src =
+    if useLocal then
+      builtins.trace "Using local workspace for mesh-sampling: ${localWorkspace}/mesh_sampling" (
+        builtins.path {
+          path = "${localWorkspace}/mesh_sampling";
+          name = "mesh-sampling-src";
+        }
+      )
     else
       # TODO: release mesh-sampling
       fetchgit {
@@ -22,9 +33,17 @@ stdenv.mkDerivation {
         sha256 = "sha256-2e1Ctq/2lj2BNyxPH3VD+owYlURyIUq82D74y4nKPeg=";
       };
 
-  nativeBuildInputs = [ cmake cli11 ];
+  nativeBuildInputs = [
+    cmake
+    cli11
+  ];
   # XXX why is libz dependency manually required here? Either qhull or assimp should bring it
-  propagatedBuildInputs = [ qhull assimp eigen libz ];
+  propagatedBuildInputs = [
+    qhull
+    assimp
+    eigen
+    libz
+  ];
 
   cmakeFlags = [
     "-DINSTALL_DOCUMENTATION=OFF"
@@ -34,8 +53,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Samplers to obtain pointclouds from CAD meshes ";
-    homepage    = "https://github.com/jrl-umi3218/mesh_sampling";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/mesh_sampling";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/omniorb-python/default.nix
+++ b/pkgs/omniorb-python/default.nix
@@ -1,4 +1,10 @@
-{ lib, fetchurl, python2, buildPythonPackage, omniorb }:
+{
+  lib,
+  fetchurl,
+  python2,
+  buildPythonPackage,
+  omniorb,
+}:
 
 buildPythonPackage rec {
 
@@ -11,7 +17,10 @@ buildPythonPackage rec {
     sha256 = "1di73mx9m639adsjzmf234zwdfzsswdc0svm5c039jcwamkxis6s";
   };
 
-  buildInputs = [ python2 omniorb ];
+  buildInputs = [
+    python2
+    omniorb
+  ];
 
   format = "other";
 
@@ -21,8 +30,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A robust high performance CORBA ORB for C++ and Python. It is freely available under the terms of the GNU Lesser General Public License (for the libraries), and GNU General Public License (for the tools). omniORB is largely CORBA 2.6 compliant";
-    homepage    = "http://omniorb.sourceforge.net/";
-    license     = licenses.gpl2Plus;
-    platforms   = platforms.unix;
+    homepage = "http://omniorb.sourceforge.net/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/openrtm-aist-python/default.nix
+++ b/pkgs/openrtm-aist-python/default.nix
@@ -1,4 +1,11 @@
-{ lib, fetchFromGitHub, python2, buildPythonPackage, openrtm-aist, doxygen }:
+{
+  lib,
+  fetchFromGitHub,
+  python2,
+  buildPythonPackage,
+  openrtm-aist,
+  doxygen,
+}:
 
 buildPythonPackage rec {
   pname = "openrtm-aist-python";
@@ -11,15 +18,19 @@ buildPythonPackage rec {
     sha256 = "0n4sjva3giw4fj1x70qksmmr421g1qbkf2w5fii9s5ykp208bjic";
   };
 
-  nativeBuildInputs = [ python2 openrtm-aist doxygen ];
+  nativeBuildInputs = [
+    python2
+    openrtm-aist
+    doxygen
+  ];
   propagatedBuildInputs = [ openrtm-aist ];
 
   doCheck = false;
 
   meta = with lib; {
     description = "OpenRTM-aist is a software platform developed on the basis of the RT middleware standard.";
-    homepage    = "https://www.openrtm.org";
-    license     = licenses.lgpl3;
-    platforms   = platforms.all;
+    homepage = "https://www.openrtm.org";
+    license = licenses.lgpl3;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/openrtm-aist/default.nix
+++ b/pkgs/openrtm-aist/default.nix
@@ -1,4 +1,17 @@
-{ stdenv, lib, fetchFromGitHub, libuuid, omniorb, which, autoconf, automake, autogen, libtool, python, ccache }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  libuuid,
+  omniorb,
+  which,
+  autoconf,
+  automake,
+  autogen,
+  libtool,
+  python,
+  ccache,
+}:
 
 stdenv.mkDerivation {
   pname = "openrtm-aist";
@@ -11,8 +24,19 @@ stdenv.mkDerivation {
     sha256 = "14xdv5kqkwz9wi1bizzypcsgg2lc7h3n3ssjr9lj0dwxn6m0m6qz";
   };
 
-  nativeBuildInputs = [ autoconf autogen automake which python ccache ];
-  propagatedBuildInputs = [ libuuid omniorb libtool ];
+  nativeBuildInputs = [
+    autoconf
+    autogen
+    automake
+    which
+    python
+    ccache
+  ];
+  propagatedBuildInputs = [
+    libuuid
+    omniorb
+    libtool
+  ];
 
   doCheck = false;
 
@@ -39,8 +63,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "OpenRTM-aist is a software platform developed on the basis of the RT middleware standard.";
-    homepage    = "https://www.openrtm.org";
-    license     = licenses.lgpl3;
-    platforms   = platforms.all;
+    homepage = "https://www.openrtm.org";
+    license = licenses.lgpl3;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/rbdyn/default.nix
+++ b/pkgs/rbdyn/default.nix
@@ -1,4 +1,13 @@
-{ stdenv, lib, cmake, spacevecalg, yaml-cpp, tinyxml-2, boost, fetchurl }:
+{
+  stdenv,
+  lib,
+  cmake,
+  spacevecalg,
+  yaml-cpp,
+  tinyxml-2,
+  boost,
+  fetchurl,
+}:
 
 stdenv.mkDerivation rec {
   pname = "rbyn";
@@ -10,7 +19,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ spacevecalg yaml-cpp tinyxml-2 boost ]; # Add other dependencies here
+  propagatedBuildInputs = [
+    spacevecalg
+    yaml-cpp
+    tinyxml-2
+    boost
+  ]; # Add other dependencies here
 
   postPatch = ''
     # Remove the include from the main CMakeLists.txt
@@ -24,8 +38,8 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Model the dynamics of rigid body systems";
-    homepage    = "https://github.com/jrl-umi3218/RBDyn";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/RBDyn";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/sch-core/default.nix
+++ b/pkgs/sch-core/default.nix
@@ -5,7 +5,7 @@
   eigen,
   doxygen,
   boost,
-  fetchurl
+  fetchurl,
 }:
 
 stdenv.mkDerivation rec {
@@ -17,8 +17,14 @@ stdenv.mkDerivation rec {
     sha256 = "aa10a427bafc3fbe4fc687d1785b079539a438597b7b6ba20ae230d5286074dd";
   };
 
-  nativeBuildInputs = [ cmake doxygen ];
-  propagatedBuildInputs = [ eigen boost ];
+  nativeBuildInputs = [
+    cmake
+    doxygen
+  ];
+  propagatedBuildInputs = [
+    eigen
+    boost
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -30,8 +36,8 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "sch-core: Effective proximity queries";
-    homepage    = "https://github.com/jrl-umi3218/sch-core";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/sch-core";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/sch-visualization/default.nix
+++ b/pkgs/sch-visualization/default.nix
@@ -12,30 +12,44 @@
   fetchgit,
   eigen,
   sch-core,
-  useLocal ? false, localWorkspace ? null,
+  useLocal ? false,
+  localWorkspace ? null,
 }:
 
 stdenv.mkDerivation rec {
   pname = "sch-visualization";
   version = "1.0.1";
 
-  src = 
+  src =
     if useLocal then
-      builtins.trace "Using local workspace for sch-visualization: ${localWorkspace}/sch-visualization"
-      (builtins.path {
-        path = "${localWorkspace}/sch-visualization";
-        name = "sch-visualization-src";
-      })
-  else
-    fetchgit {
-      url = "https://github.com/jrl-umi3218/sch-visualization";
-      rev = "a9883a9c2470c0d430306aea2f73284c255c705e";
-      hash = "sha256-hHQqPE+ijvXpHdHuHETBPI6O/Q5une+X7YwKdFAzdmg=";
-      fetchSubmodules = true;
-    };
+      builtins.trace "Using local workspace for sch-visualization: ${localWorkspace}/sch-visualization" (
+        builtins.path {
+          path = "${localWorkspace}/sch-visualization";
+          name = "sch-visualization-src";
+        }
+      )
+    else
+      fetchgit {
+        url = "https://github.com/jrl-umi3218/sch-visualization";
+        rev = "a9883a9c2470c0d430306aea2f73284c255c705e";
+        hash = "sha256-hHQqPE+ijvXpHdHuHETBPI6O/Q5une+X7YwKdFAzdmg=";
+        fetchSubmodules = true;
+      };
 
-  nativeBuildInputs = [ cmake doxygen pkg-config perl ];
-  propagatedBuildInputs = [ eigen sch-core glfw freeglut boost libGLU ];
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    pkg-config
+    perl
+  ];
+  propagatedBuildInputs = [
+    eigen
+    sch-core
+    glfw
+    freeglut
+    boost
+    libGLU
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -47,8 +61,8 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "sch-visualization: Effective proximity queries";
-    homepage    = "https://github.com/jrl-umi3218/sch-visualization";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/sch-visualization";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/spacevecalg/default.nix
+++ b/pkgs/spacevecalg/default.nix
@@ -1,4 +1,12 @@
-{ stdenv, lib, cmake, jrl-cmakemodules, eigen, boost, fetchurl }:
+{
+  stdenv,
+  lib,
+  cmake,
+  jrl-cmakemodules,
+  eigen,
+  boost,
+  fetchurl,
+}:
 
 stdenv.mkDerivation rec {
   pname = "spacevecalg";
@@ -10,7 +18,11 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ eigen boost jrl-cmakemodules ];
+  propagatedBuildInputs = [
+    eigen
+    boost
+    jrl-cmakemodules
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -22,8 +34,8 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Spatial Vector Algebra with the Eigen library";
-    homepage    = "https://github.com/jrl-umi3218/SpaceVecAlg";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/SpaceVecAlg";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/spdlog-1.12.0.nix
+++ b/pkgs/spdlog-1.12.0.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     "-DSPDLOG_BUILD_EXAMPLE=OFF"
     "-DSPDLOG_BUILD_BENCH=OFF"
     "-DSPDLOG_BUILD_TESTS=OFF"
-    "-DSPDLOG_FMT_EXTERNAL=ON"
+    "-DSPDLOG_FMT_EXTERNAL=OFF"
   ];
 
   outputs = [

--- a/pkgs/spdlog-1.12.0.nix
+++ b/pkgs/spdlog-1.12.0.nix
@@ -1,14 +1,16 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, fetchpatch
-, cmake
-, fmt
-, catch2_3
-, staticBuild ? stdenv.hostPlatform.isStatic
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  fmt,
+  catch2_3,
+  staticBuild ? stdenv.hostPlatform.isStatic,
 
-# tests
-, bear, tiledb
+  # tests
+  bear,
+  tiledb,
 }:
 
 stdenv.mkDerivation rec {
@@ -17,9 +19,9 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "gabime";
-    repo  = "spdlog";
-    rev   = "v${version}";
-    hash  = "sha256-cxTaOuLXHRU8xMz9gluYz0a93O0ez2xOxbloyc1m1ns=";
+    repo = "spdlog";
+    rev = "v${version}";
+    hash = "sha256-cxTaOuLXHRU8xMz9gluYz0a93O0ez2xOxbloyc1m1ns=";
   };
 
   patches = [
@@ -43,7 +45,11 @@ stdenv.mkDerivation rec {
     "-DSPDLOG_FMT_EXTERNAL=ON"
   ];
 
-  outputs = [ "out" "doc" "dev" ] ;
+  outputs = [
+    "out"
+    "doc"
+    "dev"
+  ];
 
   postInstall = ''
     mkdir -p $out/share/doc/spdlog
@@ -57,10 +63,10 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    description    = "Very fast, header only, C++ logging library";
-    homepage       = "https://github.com/gabime/spdlog";
-    license        = licenses.mit;
-    maintainers    = with maintainers; [ obadz ];
-    platforms      = platforms.all;
+    description = "Very fast, header only, C++ logging library";
+    homepage = "https://github.com/gabime/spdlog";
+    license = licenses.mit;
+    maintainers = with maintainers; [ obadz ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/state-observation/default.nix
+++ b/pkgs/state-observation/default.nix
@@ -1,4 +1,11 @@
-{ stdenv, lib, cmake, boost, eigen, fetchurl }:
+{
+  stdenv,
+  lib,
+  cmake,
+  boost,
+  eigen,
+  fetchurl,
+}:
 
 stdenv.mkDerivation rec {
   pname = "state-observation";
@@ -10,7 +17,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ boost eigen ];
+  propagatedBuildInputs = [
+    boost
+    eigen
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -23,8 +33,8 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Describes interfaces for state observers, and implements some observers (including linear and extended Kalman filters)";
-    homepage    = "https://github.com/jrl-umi3218/state-observation";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/state-observation";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/tasks/default.nix
+++ b/pkgs/tasks/default.nix
@@ -1,4 +1,11 @@
-{ stdenv, lib, fetchurl, cmake, rbdyn, sch-core, eigen-qld }:
+{
+  stdenv,
+  lib,
+  cmake,
+  rbdyn,
+  sch-core,
+  eigen-qld,
+}:
 
 stdenv.mkDerivation rec {
   pname = "tasks";
@@ -10,7 +17,11 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ rbdyn sch-core eigen-qld ];
+  propagatedBuildInputs = [
+    rbdyn
+    sch-core
+    eigen-qld
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -30,8 +41,8 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Real-time control for kinematics tree and list of kinematics tree";
-    homepage    = "https://github.com/jrl-umi3218/tasks";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/tasks";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/tvm/default.nix
+++ b/pkgs/tvm/default.nix
@@ -1,4 +1,12 @@
-{ stdenv, lib, cmake, eigen-qld, eigen-quadprog, boost, fetchurl, fetchgit }:
+{
+  stdenv,
+  lib,
+  cmake,
+  eigen-qld,
+  eigen-quadprog,
+  boost,
+  fetchgit,
+}:
 
 stdenv.mkDerivation {
   pname = "tvm";
@@ -15,10 +23,13 @@ stdenv.mkDerivation {
     rev = "67d09664e34db3dc8ce3d03ed77449eb552124ff";
     sha256 = "mZ40sjGG56PNgeXcXpHzyNJqmX7yProgFQ09WC1sUSs=";
   };
-  
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ eigen-qld eigen-quadprog boost ];
+  propagatedBuildInputs = [
+    eigen-qld
+    eigen-quadprog
+    boost
+  ];
 
   cmakeFlags = [
     "-DBUILD_TESTING=OFF"
@@ -33,8 +44,8 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Tasks with Variable Management";
-    homepage    = "https://github.com/jrl-umi3218/tvm";
-    license     = licenses.bsd2;
-    platforms   = platforms.all;
+    homepage = "https://github.com/jrl-umi3218/tvm";
+    license = licenses.bsd2;
+    platforms = platforms.all;
   };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -6,9 +6,11 @@
 }:
 
 let
-  mcRtcConfigs = mc-rtc-superbuild.configs ++ [ "${mc-rtc-superbuild}/etc/mc_rtc.yaml" ];
+  cfg = mc-rtc-superbuild.superbuildArgs;
+  superbuild = mc-rtc-superbuild;
+  mcRtcConfigs = cfg.configs ++ [ "${superbuild}/etc/mc_rtc.yaml" ];
 
-  title = "  ${mc-rtc-superbuild.pname} interactive shell  ";
+  title = "  ${cfg.pname} interactive shell  ";
   line = builtins.concatStringsSep "" (builtins.genList (_: "=") (builtins.stringLength title));
 in
 pkgs.mkShell {
@@ -76,25 +78,23 @@ pkgs.mkShell {
 
     echo "Runtime dependencies (store paths):"
     echo "Robot modules:"
-    for robot in ${pkgs.lib.concatStringsSep " " (map (r: "${r}") mc-rtc-superbuild.robots)}; do
+    for robot in ${pkgs.lib.concatStringsSep " " (map (r: "${r}") cfg.robots)}; do
       echo "  $robot"
     done
     echo "Plugins:"
-    for plugin in ${pkgs.lib.concatStringsSep " " (map (r: "${r}") mc-rtc-superbuild.plugins)}; do
+    for plugin in ${pkgs.lib.concatStringsSep " " (map (r: "${r}") cfg.plugins)}; do
       echo "  $plugin"
     done
     echo "Observers:"
-    for observer in ${pkgs.lib.concatStringsSep " " (map (r: "${r}") mc-rtc-superbuild.observers)}; do
+    for observer in ${pkgs.lib.concatStringsSep " " (map (r: "${r}") cfg.observers)}; do
       echo "  $observer"
     done
     echo "Controllers:"
-    for controller in ${
-      pkgs.lib.concatStringsSep " " (map (r: "${r}") mc-rtc-superbuild.controllers)
-    }; do
+    for controller in ${pkgs.lib.concatStringsSep " " (map (r: "${r}") cfg.controllers)}; do
       echo "  $controller"
     done
     echo "Apps:"
-    for app in ${pkgs.lib.concatStringsSep " " (map (r: "${r}") mc-rtc-superbuild.apps)}; do
+    for app in ${pkgs.lib.concatStringsSep " " (map (r: "${r}") cfg.apps)}; do
       echo "  $app"
     done
     echo ""

--- a/shell.nix
+++ b/shell.nix
@@ -1,31 +1,40 @@
-{ pkgs, mc-rtc-superbuild, extraBuildInputs ? [], with-ros ? false }:
+{
+  pkgs,
+  mc-rtc-superbuild,
+  extraBuildInputs ? [ ],
+  with-ros ? false,
+}:
 
-let 
-  mcRtcConfigs =
-  mc-rtc-superbuild.configs
-  ++ [ "${mc-rtc-superbuild}/etc/mc_rtc.yaml" ];
+let
+  mcRtcConfigs = mc-rtc-superbuild.configs ++ [ "${mc-rtc-superbuild}/etc/mc_rtc.yaml" ];
 
   title = "  ${mc-rtc-superbuild.pname} interactive shell  ";
   line = builtins.concatStringsSep "" (builtins.genList (_: "=") (builtins.stringLength title));
 in
 pkgs.mkShell {
   buildInputs =
-    with pkgs; [
+    with pkgs;
+    [
       mc-rtc-superbuild
       cmake
       ninja
       gdb
     ]
     ++ extraBuildInputs
-    ++ (if with-ros then [
-      colcon
-      rosPackages.jazzy.rclcpp
-      rosPackages.jazzy.geometry-msgs
-      rosPackages.jazzy.sensor-msgs
-      rosPackages.jazzy.tf2-ros
-      rosPackages.jazzy.xacro
-      # Add more ROS packages as needed
-    ] else []);
+    ++ (
+      if with-ros then
+        [
+          colcon
+          rosPackages.jazzy.rclcpp
+          rosPackages.jazzy.geometry-msgs
+          rosPackages.jazzy.sensor-msgs
+          rosPackages.jazzy.tf2-ros
+          rosPackages.jazzy.xacro
+          # Add more ROS packages as needed
+        ]
+      else
+        [ ]
+    );
 
   shellHook = ''
     export MC_RTC_PATH=${pkgs.mc-rtc}
@@ -79,7 +88,9 @@ pkgs.mkShell {
       echo "  $observer"
     done
     echo "Controllers:"
-    for controller in ${pkgs.lib.concatStringsSep " " (map (r: "${r}") mc-rtc-superbuild.controllers)}; do
+    for controller in ${
+      pkgs.lib.concatStringsSep " " (map (r: "${r}") mc-rtc-superbuild.controllers)
+    }; do
       echo "  $controller"
     done
     echo "Apps:"


### PR DESCRIPTION
We use many private repositories (robots, some controllers, etc). These are made optional by moving them to a "private" overlay, that can be enabled in flakes using the `privateFlakeModule` exposed here.