### PR TITLE
Setup attic cache and private flake

### DIFF
--- a/.github/workflows/nix-private.yml
+++ b/.github/workflows/nix-private.yml
@@ -24,13 +24,6 @@ jobs:
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_KEY }}
-
-      - name: Check ssh-agent
-        shell: bash
-        run: |
-            echo "SSH_AUTH_SOCK = ${{ env.SSH_AUTH_SOCK }}"
-            ssh-add -l
-
       - uses: cachix/install-nix-action@v31
       # read-only cache
       - uses: cachix/cachix-action@v17
@@ -56,6 +49,10 @@ jobs:
     steps:
       - uses: jlumbroso/free-disk-space@main
         if: ${{ matrix.os == 'ubuntu' }}
+      - name: Configure ssh-agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_KEY }}
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
       - uses: cachix/cachix-action@v17
@@ -107,8 +104,8 @@ jobs:
   #     - run: nix build -L .#homeConfigurations.cpene.activationPackage
   check:
     if: always()
-    name: check-macos-linux-nix
-    runs-on: ubuntu-latest
+    name: check-macos-linux-nix-private
+    runs-on: ubuntu-latest.mer
     needs:
       - fallback
       # - system

--- a/.github/workflows/nix-private.yml
+++ b/.github/workflows/nix-private.yml
@@ -24,6 +24,9 @@ jobs:
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_KEY }}
+      - name: Add gite.lirmm.fr to known_hosts
+        run: |
+          ssh-keyscan gite.lirmm.fr >> ~/.ssh/known_hosts
       - uses: cachix/install-nix-action@v31
       # read-only cache
       - uses: cachix/cachix-action@v17
@@ -53,6 +56,9 @@ jobs:
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_KEY }}
+      - name: Add gite.lirmm.fr to known_hosts
+        run: |
+          ssh-keyscan gite.lirmm.fr >> ~/.ssh/known_hosts
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
       - uses: cachix/cachix-action@v17

--- a/.github/workflows/nix-private.yml
+++ b/.github/workflows/nix-private.yml
@@ -1,0 +1,109 @@
+name: "CI - Nix - Private"
+on:
+  push:
+    branches:
+      - main
+      - private-attic
+  pull_request:
+    branches:
+      - main
+jobs:
+  populate-cache:
+    name: "${{ matrix.build }} on ${{ matrix.os }}"
+    runs-on: "${{ matrix.os }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04]
+        # test with mc-hrp2 for now
+        build: ["mc-hrp2"]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      # read-only cache
+      - uses: cachix/cachix-action@v17
+        with:
+          name: mc-rtc-nix
+          extraPullNames: "ros,gepetto"
+      # will push all paths not already in the public cache
+      - name: Setup Attic cache (private)
+        uses: ryanccn/attic-action@v0
+        with:
+          endpoint: https://attic.arntanguy.fr
+          cache: mc-rtc-nix-private
+          token: ${{ secrets.ATTIC_TOKEN }}
+      - run: nix build -L "./private#${{ matrix.build }}" --cores 4
+  complete:
+    needs: populate-cache
+    name: "complete ${{ matrix.os }}"
+    runs-on: "${{ matrix.os }}-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu] # TODO: macos
+    steps:
+      - uses: jlumbroso/free-disk-space@main
+        if: ${{ matrix.os == 'ubuntu' }}
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v17
+        with:
+          name: mc-rtc-nix
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          extraPullNames: "ros,gepetto"
+      - run: nix flake check -L ./private
+  fallback:
+    needs: complete
+    if: always() && needs.complete.result == 'failure'
+    name: "fallback ${{ matrix.os }}"
+    runs-on: "${{ matrix.os }}-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu] # TODO: macos
+    steps:
+      - uses: jlumbroso/free-disk-space@main
+        if: ${{ matrix.os == 'ubuntu' }}
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v17
+        with:
+          name: mc-rtc-nix
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          extraPullNames: "ros,gepetto"
+      - run: nix flake check -L -j 1 --cores 1
+  # system:
+  #   runs-on: "ubuntu-latest"
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #     - uses: cachix/install-nix-action@v31
+  #     - uses: cachix/cachix-action@v17
+  #       with:
+  #         name: mc-rtc-nix
+  #         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+  #         extraPullNames: ros
+  #     - run: nix build -L .#systemConfigs.default
+  # home:
+  #   runs-on: "ubuntu-latest"
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #     - uses: cachix/install-nix-action@v31
+  #     - uses: cachix/cachix-action@v17
+  #       with:
+  #         name: mc-rtc-nix
+  #         extraPullNames: "ros,gepetto"
+  #     - run: nix build -L .#homeConfigurations.cpene.activationPackage
+  check:
+    if: always()
+    name: check-macos-linux-nix
+    runs-on: ubuntu-latest
+    needs:
+      - fallback
+      # - system
+      # - home
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          allowed-skips: fallback
+          jobs: ${{ toJSON(needs) }}
+

--- a/.github/workflows/nix-private.yml
+++ b/.github/workflows/nix-private.yml
@@ -37,7 +37,7 @@ jobs:
           endpoint: https://attic.arntanguy.fr
           cache: mc-rtc-nix-private
           token: ${{ secrets.ATTIC_TOKEN }}
-      - run: nix build "./private#${{ matrix.build }}" --cores 4
+      - run: nix build -L "./private#${{ matrix.build }}" --cores 4
   complete:
     needs: populate-cache
     name: "complete ${{ matrix.os }}"
@@ -60,7 +60,7 @@ jobs:
           name: mc-rtc-nix
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           extraPullNames: "ros,gepetto"
-      - run: nix flake check ./private
+      - run: nix flake check -L ./private
   fallback:
     needs: complete
     if: always() && needs.complete.result == 'failure'

--- a/.github/workflows/nix-private.yml
+++ b/.github/workflows/nix-private.yml
@@ -19,6 +19,18 @@ jobs:
         build: ["mc-hrp2"]
     steps:
       - uses: actions/checkout@v6
+      # Configures ssh-agent if SSH_KEY secret exists
+      - name: Configure ssh-agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_KEY }}
+
+      - name: Check ssh-agent
+        shell: bash
+        run: |
+            echo "SSH_AUTH_SOCK = ${{ env.SSH_AUTH_SOCK }}"
+            ssh-add -l
+
       - uses: cachix/install-nix-action@v31
       # read-only cache
       - uses: cachix/cachix-action@v17

--- a/.github/workflows/nix-private.yml
+++ b/.github/workflows/nix-private.yml
@@ -105,7 +105,7 @@ jobs:
   check:
     if: always()
     name: check-macos-linux-nix-private
-    runs-on: ubuntu-latest.mer
+    runs-on: ubuntu-latest
     needs:
       - fallback
       # - system

--- a/.github/workflows/nix-private.yml
+++ b/.github/workflows/nix-private.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         # test with mc-hrp2 for now
-        build: ["mc-hrp2"]
+        build: [ "mc-hrp2", "mc-rtc-superbuild-private" ]
     steps:
       - uses: actions/checkout@v6
       # Configures ssh-agent if SSH_KEY secret exists
@@ -37,7 +37,7 @@ jobs:
           endpoint: https://attic.arntanguy.fr
           cache: mc-rtc-nix-private
           token: ${{ secrets.ATTIC_TOKEN }}
-      - run: nix build -L "./private#${{ matrix.build }}" --cores 4
+      - run: nix build "./private#${{ matrix.build }}" --cores 4
   complete:
     needs: populate-cache
     name: "complete ${{ matrix.os }}"
@@ -60,7 +60,7 @@ jobs:
           name: mc-rtc-nix
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           extraPullNames: "ros,gepetto"
-      - run: nix flake check -L ./private
+      - run: nix flake check ./private
   fallback:
     needs: complete
     if: always() && needs.complete.result == 'failure'

--- a/.github/workflows/nix-private.yml
+++ b/.github/workflows/nix-private.yml
@@ -3,12 +3,16 @@ on:
   push:
     branches:
       - main
-      - private-attic
   pull_request:
     branches:
       - main
 jobs:
   populate-cache:
+    # - This condition allows the job to run if:
+    #   - The workflow is not triggered by a pull request (`github.event_name != 'pull_request'`), or
+    #   - The PR's source repo is the same as the base repo.
+    # This is done to make sure that the required secrets are available to the CI
+    if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name || github.event_name != 'pull_request'
     name: "${{ matrix.build }} on ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
     strategy:
@@ -42,6 +46,7 @@ jobs:
           token: ${{ secrets.ATTIC_TOKEN }}
       - run: nix build -L "./private#${{ matrix.build }}" --cores 4
   complete:
+    if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name || github.event_name != 'pull_request'
     needs: populate-cache
     name: "complete ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}-latest"
@@ -68,6 +73,7 @@ jobs:
           extraPullNames: "ros,gepetto"
       - run: nix flake check -L ./private
   fallback:
+    if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name || github.event_name != 'pull_request'
     needs: complete
     if: always() && needs.complete.result == 'failure'
     name: "fallback ${{ matrix.os }}"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,6 +2,7 @@ pull_request_rules:
   - name: merge [bot] PRs when CI pass
     conditions:
       - check-success = "check-macos-linux-nix"
+      - check-success = "check-macos-linux-nix-private"
       - or:
           - author = dependabot[bot]
           - author = gepetto-flake-updater[bot]

--- a/flake.nix
+++ b/flake.nix
@@ -30,15 +30,10 @@
     inputs.flake-parts.lib.mkFlake { inherit inputs; } (
       { ... }:
       let
-        enablePrivateOverlay = false;
         flakeModule = inputs.flake-parts.lib.importApply ./module.nix {
           inherit (inputs) gepetto jrl-cmakemodulesv2;
-          inherit enablePrivateOverlay;
         };
-        flakeModulePrivate = inputs.flake-parts.lib.importApply ./module.nix {
-          inherit (inputs) gepetto jrl-cmakemodulesv2;
-          enablePrivateOverlay = true;
-        };
+
       in
       {
         systems = import inputs.systems;
@@ -51,7 +46,6 @@
         ];
         flake = {
           inherit flakeModule;
-          inherit flakeModulePrivate;
           lib.mkFlakoboros =
             localInputs: module:
             inputs.flake-parts.lib.mkFlake { inputs = localInputs; } (args: {
@@ -77,109 +71,9 @@
           };
         };
         perSystem =
-          {
-            inputs', # per-system inputs
-            pkgs,
-            ...
-          }:
-          {
-            packages =
-              inputs'.gepetto.packages
-              // {
-                # Main dependencies
-                spacevecalg = pkgs.spacevecalg;
-                rbdyn = pkgs.rbdyn;
-                sch-core = pkgs.sch-core;
-                tasks = pkgs.tasks;
-                tvm = pkgs.tvm;
-                eigen-quadprog = pkgs.eigen-quadprog;
-                eigen-qld = pkgs.eigen-qld;
-                state-observation = pkgs.state-observation;
-                mesh-sampling = pkgs.mesh-sampling;
-                eigen-fmt = pkgs.eigen-fmt;
-
-                # mc-rtc
-                mc-rtc-data = pkgs.mc-rtc-data;
-                mc-rtc = pkgs.mc-rtc;
-
-                # Main GUIs and applications
-                mc-rtc-magnum = pkgs.mc-rtc-magnum;
-                mc-mujoco = pkgs.mc-mujoco;
-                mc-rtc-ticker = pkgs.mc-rtc-ticker;
-                # Control interfaces
-                mc-franka = pkgs.mc-franka;
-
-                # Main superbuild configurations
-                mc-rtc-superbuild = pkgs.mc-rtc-superbuild;
-                # Includes private repositories
-                mc-rtc-superbuild-full = pkgs.mc-rtc-superbuild-full;
-                # Main controllers
-                panda-prosthesis = pkgs.panda-prosthesis;
-                polytopeController = pkgs.polytopeController;
-
-                # Main plugins
-                mc-force-shoe-plugin = pkgs.mc-force-shoe-plugin;
-
-                # Main robots
-                mc-g1 = pkgs.mc-g1;
-                mc-h1 = pkgs.mc-h1;
-                mc-ur5e = pkgs.mc-ur5e;
-                mc-panda = pkgs.mc-panda;
-                mc-panda-lirmm = pkgs.mc-panda-lirmm;
-              }
-              // (
-                if enablePrivateOverlay then
-                  {
-                    # Private robots
-                    mc-hrp2 = pkgs.mc-hrp2;
-                    mc-hrp4 = pkgs.mc-hrp4;
-                    mc-hrp5-p = pkgs.mc-hrp5-p;
-                    # Fixme this repository is far too big!
-                    mc-rhps1 = pkgs.mc-rhps1;
-
-                    # Superbuild configurations needing at least one private package
-                    mc-rtc-superbuild-private = pkgs.mc-rtc-superbuild-private;
-                    mc-rtc-superbuild-hugo = pkgs.mc-rtc-superbuild-hugo;
-                  }
-                else
-                  { }
-              );
-            devShells =
-              inputs'.gepetto.devShells
-              // {
-                mc-rtc-superbuild-minimal = import ./shell.nix {
-                  inherit pkgs;
-                  with-ros = true;
-                  mc-rtc-superbuild = pkgs.mc-rtc-superbuild-minimal;
-                };
-                mc-rtc-superbuild = import ./shell.nix {
-                  inherit pkgs;
-                  with-ros = true;
-                  mc-rtc-superbuild = pkgs.mc-rtc-superbuild;
-                };
-                mc-rtc-superbuild-all-public-robots = import ./shell.nix {
-                  inherit pkgs;
-                  with-ros = true;
-                  mc-rtc-superbuild = pkgs.mc-rtc-superbuild-all-public-robots;
-                };
-                mc-rtc-superbuild-full = import ./shell.nix {
-                  inherit pkgs;
-                  with-ros = true;
-                  mc-rtc-superbuild = pkgs.mc-rtc-superbuild-full;
-                };
-              }
-              // (
-                if enablePrivateOverlay then
-                  {
-                    mc-rtc-superbuild-private = import ./shell.nix {
-                      inherit pkgs;
-                      with-ros = true;
-                      mc-rtc-superbuild = pkgs.mc-rtc-superbuild-private;
-                    };
-                  }
-                else
-                  { }
-              );
+          { inputs', pkgs, ... }:
+          import ./perSystem-shared.nix {
+            inherit pkgs inputs';
           };
       }
     );

--- a/overlay-private.nix
+++ b/overlay-private.nix
@@ -8,6 +8,7 @@
     callWithRos = pkg: args: prev.callPackage pkg (args // { inherit with-ros; });
   in
   {
+    eigen-lssol = prev.callPackage ./pkgs/eigen-lssol/default.nix { };
     hrp2-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/hrp2-description.nix { };
     hrp4-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/hrp4-description.nix { };
     hrp5-p-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/hrp5-p-description.nix { };
@@ -21,6 +22,17 @@
     hrp4-mj-description = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/hrp4-mj-description.nix { };
     hrp5p-mj-description = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/hrp5p-mj-description.nix { };
     # TODO: hrp2-mj-description does not exist
+
+    tasks-lssol = prev.callPackage ./pkgs/tasks {
+      with-lssol = true;
+    };
+    # make tasks with lssol the new default
+    tasks = final.tasks-lssol;
+
+    # mc-rtc with lssol
+    mc-rtc = prev.mc-rtc.override {
+      tasks = final.tasks-lssol;
+    };
 
     # mc-mujoco with private robots
     mc-mujoco-robots-private = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix {

--- a/overlay-private.nix
+++ b/overlay-private.nix
@@ -50,21 +50,5 @@
         ];
       };
     };
-
-    # TODO move to Hugo's
-    mc-rtc-superbuild-hugo = prev.callPackage ./pkgs/mc-rtc/mc-rtc-superbuild-standalone.nix {
-      superbuildArgs = prev.mc-rtc-superbuild-full.superbuildArgs // {
-        pname = "mc-rtc-superbuild-hugo";
-        robots = [ final.mc-rhps1 ];
-        # observers = [mc-state-observation]; # FIXME missing Attitude observer from mc_state_observation
-        controllers = [ final.polytopeController ];
-        configs = [ "${final.polytopeController}/lib/mc_controller/etc/mc_rtc.yaml" ];
-        plugins = [ final.mc-force-shoe-plugin-hugo ];
-        apps = [
-          final.mc-rtc-magnum-hugo
-          final.mc-mujoco-hugo
-        ];
-      };
-    };
   }
 )

--- a/overlay-private.nix
+++ b/overlay-private.nix
@@ -33,6 +33,8 @@
     mc-rtc = prev.mc-rtc.override {
       tasks = final.tasks-lssol;
     };
+    # TODO ask I2S Bordeaux to make it public
+    politopix = prev.callPackage ./pkgs/3rd-party/politopix.nix {};
 
     # mc-mujoco with private robots
     mc-mujoco-robots-private = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix {

--- a/overlay.nix
+++ b/overlay.nix
@@ -52,7 +52,8 @@
     sch-core = prev.callPackage ./pkgs/sch-core { };
     #sch-visualization = prev.callPackage ./pkgs/sch-visualization {};
     sch-visualization = prev.callPackage ./pkgs/sch-visualization { };
-    tasks = prev.callPackage ./pkgs/tasks { };
+    tasks-qld = prev.callPackage ./pkgs/tasks { };
+    tasks = final.tasks-qld;
     # mc-rtc-data = prev.callPackage ./pkgs/mc-rtc-data { with-ros = false; };
     mc-rtc-data = callWithRos ./pkgs/mc-rtc-data { };
     state-observation = prev.callPackage ./pkgs/state-observation { };

--- a/overlay.nix
+++ b/overlay.nix
@@ -198,9 +198,6 @@
     eigen-fmt = prev.callPackage ./pkgs/3rd-party/eigen-fmt {
       fmt = prev.fmt_10;
     };
-    politopix = prev.callPackage ./pkgs/3rd-party/politopix.nix {
-      fetchurl = final.stdenv.fetchurlBoot;
-    };
 
     imguizmo = prev.callPackage ./pkgs/3rd-party/imguizmo.nix {
       jrl-cmakemodules = final.jrl-cmakemodulesv2;

--- a/perSystem-shared.nix
+++ b/perSystem-shared.nix
@@ -1,0 +1,79 @@
+{
+  pkgs,
+  inputs',
+  extraPackages ? { },
+  extraDevShells ? { },
+}:
+
+{
+  packages =
+    inputs'.gepetto.packages
+    // {
+      # Main dependencies
+      spacevecalg = pkgs.spacevecalg;
+      rbdyn = pkgs.rbdyn;
+      sch-core = pkgs.sch-core;
+      tasks = pkgs.tasks;
+      tvm = pkgs.tvm;
+      eigen-quadprog = pkgs.eigen-quadprog;
+      eigen-qld = pkgs.eigen-qld;
+      state-observation = pkgs.state-observation;
+      mesh-sampling = pkgs.mesh-sampling;
+      eigen-fmt = pkgs.eigen-fmt;
+
+      # mc-rtc
+      mc-rtc-data = pkgs.mc-rtc-data;
+      mc-rtc = pkgs.mc-rtc;
+
+      # Main GUIs and applications
+      mc-rtc-magnum = pkgs.mc-rtc-magnum;
+      mc-mujoco = pkgs.mc-mujoco;
+      mc-rtc-ticker = pkgs.mc-rtc-ticker;
+      # Control interfaces
+      mc-franka = pkgs.mc-franka;
+
+      # Main superbuild configurations
+      mc-rtc-superbuild = pkgs.mc-rtc-superbuild;
+      mc-rtc-superbuild-full = pkgs.mc-rtc-superbuild-full;
+      # Main controllers
+      panda-prosthesis = pkgs.panda-prosthesis;
+      polytopeController = pkgs.polytopeController;
+
+      # Main plugins
+      mc-force-shoe-plugin = pkgs.mc-force-shoe-plugin;
+
+      # Main robots
+      mc-g1 = pkgs.mc-g1;
+      mc-h1 = pkgs.mc-h1;
+      mc-ur5e = pkgs.mc-ur5e;
+      mc-panda = pkgs.mc-panda;
+      mc-panda-lirmm = pkgs.mc-panda-lirmm;
+    }
+    // extraPackages;
+
+  devShells =
+    inputs'.gepetto.devShells
+    // {
+      mc-rtc-superbuild-minimal = import ./shell.nix {
+        inherit pkgs;
+        with-ros = true;
+        mc-rtc-superbuild = pkgs.mc-rtc-superbuild-minimal;
+      };
+      mc-rtc-superbuild = import ./shell.nix {
+        inherit pkgs;
+        with-ros = true;
+        mc-rtc-superbuild = pkgs.mc-rtc-superbuild;
+      };
+      mc-rtc-superbuild-all-public-robots = import ./shell.nix {
+        inherit pkgs;
+        with-ros = true;
+        mc-rtc-superbuild = pkgs.mc-rtc-superbuild-all-public-robots;
+      };
+      mc-rtc-superbuild-full = import ./shell.nix {
+        inherit pkgs;
+        with-ros = true;
+        mc-rtc-superbuild = pkgs.mc-rtc-superbuild-full;
+      };
+    }
+    // extraDevShells;
+}

--- a/perSystem-shared.nix
+++ b/perSystem-shared.nix
@@ -14,6 +14,7 @@
       rbdyn = pkgs.rbdyn;
       sch-core = pkgs.sch-core;
       tasks = pkgs.tasks;
+      tasks-qld = pkgs.tasks-qld;
       tvm = pkgs.tvm;
       eigen-quadprog = pkgs.eigen-quadprog;
       eigen-qld = pkgs.eigen-qld;

--- a/pkgs/3rd-party/politopix.nix
+++ b/pkgs/3rd-party/politopix.nix
@@ -1,7 +1,6 @@
 {
   stdenv,
   lib,
-  fetchurl,
   cmake,
   boost,
 }:
@@ -10,27 +9,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "politopix";
   version = "1.0.0";
 
-  src =
-    # fetchFromGitHub {
-    #   owner = "Hugo-L3174";
-    #   repo = "politopix";
-    #   tag = "v${finalAttrs.version}";
-    #   hash = "";
-    # };
-
-    # XXX: this is built from a private github repository
-    # TODO: provide documentation
-    # To make it work we need to setup a netrc file in /etc/nix/netrc and configure nix
-    # sandbox to use it
-    # see: https://nixos.wiki/wiki/Enterprise and https://discourse.nixos.org/t/how-to-fetchurl-with-credentials/11994/5
-    # and my own nixos configuration here: https://github.com/arntanguy/nixos-dotfiles/commit/9ae45cb3cd73b0428382e64641b1345565fdeb12
-    fetchurl {
-      url = "https://github.com/Hugo-L3174/politopix/archive/refs/tags/v${finalAttrs.version}.tar.gz";
-      # To get the hash:
-      # - download release from github
-      # - nix hash file <release>.tar.gz
-      sha256 = "sha256-xAlIXz3yviOKN0AjF2kGP06TJ4HEymMNdjbRdOkbi6I=";
-    };
+  # XXX: this is built from a private github repository
+  src = builtins.trace "politopix is currently a private repository, ask I2S Bordeaux to make it public" (builtins.fetchGit {
+    url = "git@github.com:Hugo-L3174/politopix";
+    rev = "f625b42de4404eea16aabcf720f2cee19dfdc406";
+  });
 
   nativeBuildInputs = [ cmake ];
   propagatedBuildInputs = [ boost ];

--- a/pkgs/eigen-lssol/default.nix
+++ b/pkgs/eigen-lssol/default.nix
@@ -1,0 +1,53 @@
+{
+  stdenv,
+  lib,
+  cmake,
+  pkg-config,
+  doxygen,
+  gfortran,
+  boost,
+  eigen,
+}:
+
+stdenv.mkDerivation (_finalAttrs: {
+  pname = "eigen-lssol";
+  version = "0.0.0";
+
+  src = builtins.fetchGit {
+    url = "git@gite.lirmm.fr:multi-contact/eigen-lssol.git";
+    # Master
+    rev = "4663b177a04a2d397bb2e4e3f62ae139e911cac3";
+    submodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    doxygen
+    gfortran
+  ];
+  propagatedBuildInputs = [
+    eigen
+    boost
+  ];
+
+  cmakeFlags = [
+    "-DPYTHON_BINDING=OFF"
+    "-DINSTALL_DOCUMENTATION=OFF"
+  ];
+
+  postPatch = ''
+    # Require C++14 instead of C++11
+    substituteInPlace CMakeLists.txt \
+      --replace "set(CMAKE_CXX_STANDARD 11)" "set(CMAKE_CXX_STANDARD 14)"
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "eigen-lssol allow to use the LSSOL QP solver with the Eigen3 library";
+    homepage = "https://gite.lirmm.fr/multi-contact/eigen-lssol";
+    license = licenses.unfree;
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/mc-rtc/robots/modules/mc-g1.nix
+++ b/pkgs/mc-rtc/robots/modules/mc-g1.nix
@@ -19,11 +19,12 @@ stdenv.mkDerivation {
   pname = "mc-g1";
   version = "1.0.0";
 
-  src = fetchFromGitHub {
+  src = 
+  fetchFromGitHub {
     owner = "isri-aist";
     repo = "mc_g1";
-    rev = "d30edab21f5ec00ef737e55d56ba5e2afc89460e";
-    hash = "sha256-Ispz48omVbcgCpCHwZ3XhUF0UcCc2hQllprGGB0O01Y=";
+    rev = "7e35e3fc0e3e0d9e2edbabbac2c5ca7b79e93bac";
+    hash = "sha256-k3A52LUzA44C/b8/ztvtbpJ4lh20f7Nzk1rOfufJrKc=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/mc-rtc/robots/modules/mc-g1.nix
+++ b/pkgs/mc-rtc/robots/modules/mc-g1.nix
@@ -19,8 +19,7 @@ stdenv.mkDerivation {
   pname = "mc-g1";
   version = "1.0.0";
 
-  src = 
-  fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "isri-aist";
     repo = "mc_g1";
     rev = "7e35e3fc0e3e0d9e2edbabbac2c5ca7b79e93bac";

--- a/pkgs/tasks/default.nix
+++ b/pkgs/tasks/default.nix
@@ -5,10 +5,12 @@
   rbdyn,
   sch-core,
   eigen-qld,
+  with-lssol ? false,
+  eigen-lssol ? null,
 }:
 
 stdenv.mkDerivation rec {
-  pname = "tasks";
+  pname = if (with-lssol && eigen-lssol != null) then "tasks-lssol" else "tasks-qld";
   version = "v1.8.2";
 
   src = fetchTarball {
@@ -21,10 +23,10 @@ stdenv.mkDerivation rec {
     rbdyn
     sch-core
     eigen-qld
-  ];
+  ]
+  ++ lib.optional (with-lssol && eigen-lssol != null) eigen-lssol;
 
   cmakeFlags = [
-    "-DBUILD_TESTING=OFF"
     "-DPYTHON_BINDING=OFF"
     "-DINSTALL_DOCUMENTATION=OFF"
   ];

--- a/private/flake.lock
+++ b/private/flake.lock
@@ -1,0 +1,641 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "gepetto",
+          "system-manager",
+          "userborn",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flakoboros": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nix-ros-overlay": "nix-ros-overlay",
+        "nixpkgs": [
+          "gepetto",
+          "gazebros2nix",
+          "flakoboros",
+          "nix-ros-overlay",
+          "nixpkgs"
+        ],
+        "systems": [
+          "gepetto",
+          "gazebros2nix",
+          "flakoboros",
+          "nix-ros-overlay",
+          "flake-utils",
+          "systems"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1776113076,
+        "narHash": "sha256-rQp/6mgQc4szevay50RbGXOXwL3xC7oHktywFPrmbAM=",
+        "owner": "gepetto",
+        "repo": "flakoboros",
+        "rev": "07a89fe2a47f2f0364e795cf3e69c045de14a3b2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gepetto",
+        "repo": "flakoboros",
+        "type": "github"
+      }
+    },
+    "gazebros2nix": {
+      "inputs": {
+        "flake-parts": [
+          "gepetto",
+          "gazebros2nix",
+          "flakoboros",
+          "flake-parts"
+        ],
+        "flakoboros": "flakoboros",
+        "nix-ros-overlay": [
+          "gepetto",
+          "gazebros2nix",
+          "flakoboros",
+          "nix-ros-overlay"
+        ],
+        "nixpkgs": [
+          "gepetto",
+          "gazebros2nix",
+          "flakoboros",
+          "nixpkgs"
+        ],
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "systems": [
+          "gepetto",
+          "gazebros2nix",
+          "flakoboros",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "gepetto",
+          "gazebros2nix",
+          "flakoboros",
+          "treefmt-nix"
+        ],
+        "uv2nix": "uv2nix"
+      },
+      "locked": {
+        "lastModified": 1776113232,
+        "narHash": "sha256-VtzAiez4xLmUY/TrQ31ECKjnOFDrnorQcu6WfsAF2nk=",
+        "owner": "gepetto",
+        "repo": "gazebros2nix",
+        "rev": "43783392a112e894b857bdb56ede7044437069f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gepetto",
+        "repo": "gazebros2nix",
+        "type": "github"
+      }
+    },
+    "gepetto": {
+      "inputs": {
+        "flake-parts": [
+          "gepetto",
+          "gazebros2nix",
+          "flake-parts"
+        ],
+        "flakoboros": [
+          "gepetto",
+          "gazebros2nix",
+          "flakoboros"
+        ],
+        "gazebros2nix": "gazebros2nix",
+        "home-manager": "home-manager",
+        "nix-ros-overlay": [
+          "gepetto",
+          "gazebros2nix",
+          "nix-ros-overlay"
+        ],
+        "nix-system-graphics": "nix-system-graphics",
+        "nixpkgs": [
+          "gepetto",
+          "gazebros2nix",
+          "nixpkgs"
+        ],
+        "system-manager": "system-manager",
+        "systems": [
+          "gepetto",
+          "gazebros2nix",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "gepetto",
+          "gazebros2nix",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776491960,
+        "narHash": "sha256-0W5MuLm2hxLGrj1JGVsVsnr97kq2zQyMPcExh/+xLl0=",
+        "owner": "gepetto",
+        "repo": "nix",
+        "rev": "5528d9b9389e2c22ce1ef555ee63b5587f9719cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gepetto",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "gepetto",
+          "system-manager",
+          "userborn",
+          "pre-commit-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "gepetto",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775425411,
+        "narHash": "sha256-KY6HsebJHEe5nHOWP7ur09mb0drGxYSzE3rQxy62rJo=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "0d02ec1d0a05f88ef9e74b516842900c41f0f2fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-25.11",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "jrl-cmakemodulesv2": {
+      "inputs": {
+        "flake-parts": "flake-parts_3",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1776437123,
+        "narHash": "sha256-PWuaFy4F/xs62NqQNTb62FRVoS5taO1fntyG7mx4Y8E=",
+        "owner": "ahoarau",
+        "repo": "jrl-cmakemodules",
+        "rev": "93232dc5449ea00cea3ab255b80e64f35f05dc06",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ahoarau",
+        "ref": "jrl-next",
+        "repo": "jrl-cmakemodules",
+        "type": "github"
+      }
+    },
+    "nix-ros-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1775764892,
+        "narHash": "sha256-l1UbHppd5KaU4K/TQPIXf9wnVifH4Tgrx5z2GFoq/bw=",
+        "owner": "lopsided98",
+        "repo": "nix-ros-overlay",
+        "rev": "0a4e8cf51001d2d1c613f95dadd3853da42c0164",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lopsided98",
+        "ref": "develop",
+        "repo": "nix-ros-overlay",
+        "type": "github"
+      }
+    },
+    "nix-system-graphics": {
+      "inputs": {
+        "nixpkgs": [
+          "gepetto",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1763296639,
+        "narHash": "sha256-K9JBscC7ApwCnl0wR0sVkxrKFsoDYVqXN5fOujvyBWA=",
+        "owner": "soupglasses",
+        "repo": "nix-system-graphics",
+        "rev": "ac37f0f3ec0cb15d63a520918433c794d01d9dac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "soupglasses",
+        "repo": "nix-system-graphics",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks-nix": {
+      "inputs": {
+        "flake-compat": [
+          "gepetto",
+          "system-manager",
+          "userborn",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "gepetto",
+          "system-manager",
+          "userborn",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769069492,
+        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "gepetto",
+          "gazebros2nix",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "gepetto",
+          "gazebros2nix",
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "gepetto",
+          "gazebros2nix",
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773870109,
+        "narHash": "sha256-ZoTdqZP03DcdoyxvpFHCAek4bkPUTUPUF3oCCgc3dP4=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "b6e74f433b02fa4b8a7965ee24680f4867e2926f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "gepetto",
+          "gazebros2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775439158,
+        "narHash": "sha256-NHY9SJNU019n+8NCabBDtmuzRFeE2gZlYKHowp9bV24=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "fb6b728260f3f32761367e9fd1e1a25b4245bcd0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": [
+          "gepetto",
+          "flake-parts"
+        ],
+        "gepetto": "gepetto",
+        "jrl-cmakemodulesv2": "jrl-cmakemodulesv2",
+        "nixpkgs": [
+          "gepetto",
+          "nixpkgs"
+        ],
+        "systems": [
+          "gepetto",
+          "systems"
+        ]
+      }
+    },
+    "system-manager": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "gepetto",
+          "nixpkgs"
+        ],
+        "userborn": "userborn"
+      },
+      "locked": {
+        "lastModified": 1776108115,
+        "narHash": "sha256-QDa17vvigUyEAk/kTkDHOBFqmbWIe7aZDCjSgl9BG2c=",
+        "owner": "numtide",
+        "repo": "system-manager",
+        "rev": "e028253c2f1ea1b3eba2ce84ae8f770d823fe4ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "system-manager",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "gepetto",
+          "gazebros2nix",
+          "flakoboros",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "userborn": {
+      "inputs": {
+        "flake-compat": [
+          "gepetto",
+          "system-manager",
+          "flake-compat"
+        ],
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "gepetto",
+          "system-manager",
+          "nixpkgs"
+        ],
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix",
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1770377964,
+        "narHash": "sha256-q2pnlX2IW0kg80GLFnwWd/GigIpkuZnyKPLhrgJql3E=",
+        "owner": "jfroche",
+        "repo": "userborn",
+        "rev": "55c2cd7952c207a62736a5bbd9499ea73da18d24",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jfroche",
+        "ref": "system-manager",
+        "repo": "userborn",
+        "type": "github"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "gepetto",
+          "gazebros2nix",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "gepetto",
+          "gazebros2nix",
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775706324,
+        "narHash": "sha256-BTb4sydzX2B5/oNbvCdQFeSbk97xEnbb8bk84CiKCOs=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "5707df99097375896a3dda811d492a2fabe63500",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/private/flake.nix
+++ b/private/flake.nix
@@ -1,0 +1,67 @@
+{
+  description = "mc-rtc private flake (with private overlay and packages)";
+
+  inputs = {
+    gepetto.url = "github:gepetto/nix";
+    flake-parts.follows = "gepetto/flake-parts";
+    nixpkgs.follows = "gepetto/nixpkgs";
+    systems.follows = "gepetto/systems";
+    jrl-cmakemodulesv2 = {
+      url = "github:ahoarau/jrl-cmakemodules?ref=jrl-next";
+    };
+  };
+
+  nixConfig = {
+    extra-substituters = [
+      "https://mc-rtc-nix.cachix.org"
+      "https://attic.arntanguy.fr/mc-rtc-nix-private"
+      "https://gepetto.cachix.org"
+      "https://attic.iid.ciirc.cvut.cz/ros"
+    ];
+    extra-trusted-public-keys = [
+      "mc-rtc-nix.cachix.org-1:5M3sLvHXJCep4wc1tQl7QuFWL2eH2I0jkuvWtqJDYQs="
+      "mc-rtc-nix-private:jXpQCG0bFJIJxAuQpHQEyRsF+PyUcvIyFmnBcR5kEuo="
+      "gepetto.cachix.org-1:toswMl31VewC0jGkN6+gOelO2Yom0SOHzPwJMY2XiDY="
+      "ros:JR95vUYsShSqfA1VTYoFt1Nz6uXasm5QrcOsGry9f6Q="
+    ];
+  };
+
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } (
+      { ... }:
+      let
+        flakeModulePrivate = inputs.flake-parts.lib.importApply ../module.nix {
+          inherit (inputs) gepetto jrl-cmakemodulesv2;
+          enablePrivateOverlay = true;
+        };
+      in
+      {
+        systems = import inputs.systems;
+        imports = [
+          flakeModulePrivate
+        ];
+        perSystem =
+          { inputs', pkgs, ... }:
+          import ../perSystem-shared.nix {
+            inherit pkgs inputs';
+            extraPackages = {
+              # Private robots
+              mc-hrp2 = pkgs.mc-hrp2;
+              mc-hrp4 = pkgs.mc-hrp4;
+              mc-hrp5-p = pkgs.mc-hrp5-p;
+              mc-rhps1 = pkgs.mc-rhps1;
+              # Superbuild configurations needing at least one private package
+              mc-rtc-superbuild-private = pkgs.mc-rtc-superbuild-private;
+            };
+            extraDevShells = {
+              mc-rtc-superbuild-private = import ../shell.nix {
+                inherit pkgs;
+                with-ros = true;
+                mc-rtc-superbuild = pkgs.mc-rtc-superbuild-private;
+              };
+            };
+          };
+      }
+    );
+}

--- a/private/flake.nix
+++ b/private/flake.nix
@@ -51,6 +51,7 @@
               mc-hrp4 = pkgs.mc-hrp4;
               mc-hrp5-p = pkgs.mc-hrp5-p;
               mc-rhps1 = pkgs.mc-rhps1;
+              tasks-lssol = pkgs.tasks-lssol;
               # Superbuild configurations needing at least one private package
               mc-rtc-superbuild-private = pkgs.mc-rtc-superbuild-private;
             };

--- a/private/flake.nix
+++ b/private/flake.nix
@@ -52,6 +52,7 @@
               mc-hrp5-p = pkgs.mc-hrp5-p;
               mc-rhps1 = pkgs.mc-rhps1;
               tasks-lssol = pkgs.tasks-lssol;
+              politopix = pkgs.politopix;
               # Superbuild configurations needing at least one private package
               mc-rtc-superbuild-private = pkgs.mc-rtc-superbuild-private;
             };


### PR DESCRIPTION
- split repositiories in public/private overlays
- private overlay is private in the sense that we need credential to access the project and thus cannot push the output to a public cache
- split the flake in a public flake.nix and a private private/flake.nix
- split flake module with a `flakeModule` and `flakeModulePrivate`
- setup and seed an attic binary cache on my personnal private server
- attic documentation coming later