### PR TITLE
Revert "mc-rtc(spdlog): all fmt version 8..12 now supported, remove spdlog override"

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -113,7 +113,11 @@
     # 1.12.0 against fmt_9 (technically it supports fmt_10 but nixpkgs used to build it against fmt_9 on purpose). To avoid rebuilding the world, we leave fmt_12 everywhere else,
     # this might cause some headache down the line.
     # TODO: patch mc-rtc and eigen-fmt with fmt_12 support
-    mc-rtc = callWithRos ./pkgs/mc-rtc/mc-rtc.nix { };
+    mc-rtc = callWithRos ./pkgs/mc-rtc/mc-rtc.nix {
+      spdlog = prev.callPackage ./pkgs/spdlog-1.12.0.nix {
+        fmt = final.fmt_9;
+      };
+    };
     mc-rtc-python-utils = prev.callPackage ./pkgs/mc-rtc/mc-rtc-python-utils.nix { };
     #mc-rtc = callWithRos ./pkgs/mc-rtc/mc-rtc.nix {};
     # mc-rtc-rviz-panel = prev.libsForQt5.callPackage ./pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix { inherit useLocal; inherit localWorkspace; };

--- a/pkgs/mc-rtc/mc-rtc-common.nix
+++ b/pkgs/mc-rtc/mc-rtc-common.nix
@@ -7,8 +7,8 @@ let
   src = fetchFromGitHub {
     owner = "jrl-umi3218";
     repo = "mc_rtc";
-    rev = "c193a3d46c6e8f9bbf5275e612f6ddf3f53ca6b2";
-    hash = "sha256-jrQc7LLAvb0BD8eTSdeqUKayz8yOru6wno3s7/sLQA4=";
+    rev = "d09e062acd60bb07c8e76b74a50f460ba2a2e6ed";
+    hash = "sha256-W4Mx8DCYdEvaTFoXxkaT+9WKwd4be8tX8FJY7Gtfn84=";
   };
 in
 {

--- a/pkgs/spdlog-1.12.0.nix
+++ b/pkgs/spdlog-1.12.0.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  fmt,
+  catch2_3,
+  staticBuild ? stdenv.hostPlatform.isStatic,
+
+  # tests
+  bear,
+  tiledb,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "spdlog";
+  version = "1.12.0";
+
+  src = fetchFromGitHub {
+    owner = "gabime";
+    repo = "spdlog";
+    rev = "v${version}";
+    hash = "sha256-cxTaOuLXHRU8xMz9gluYz0a93O0ez2xOxbloyc1m1ns=";
+  };
+
+  patches = [
+    # Fix a broken test, remove with the next release.
+    (fetchpatch {
+      url = "https://github.com/gabime/spdlog/commit/2ee8bac78e6525a8ad9a9196e65d502ce390d83a.patch";
+      hash = "sha256-L79yOkm3VY01jmxNctfneTLmOA5DEQeNNGC8LbpJiOc=";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [ fmt ];
+  checkInputs = [ catch2_3 ];
+
+  cmakeFlags = [
+    "-DSPDLOG_BUILD_SHARED=${if staticBuild then "OFF" else "ON"}"
+    "-DSPDLOG_BUILD_STATIC=${if staticBuild then "ON" else "OFF"}"
+    "-DSPDLOG_BUILD_EXAMPLE=OFF"
+    "-DSPDLOG_BUILD_BENCH=OFF"
+    "-DSPDLOG_BUILD_TESTS=OFF"
+    "-DSPDLOG_FMT_EXTERNAL=OFF"
+  ];
+
+  outputs = [
+    "out"
+    "doc"
+    "dev"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/doc/spdlog
+    cp -rv ../example $out/share/doc/spdlog
+  '';
+
+  doCheck = true;
+
+  passthru.tests = {
+    inherit bear tiledb;
+  };
+
+  meta = with lib; {
+    description = "Very fast, header only, C++ logging library";
+    homepage = "https://github.com/gabime/spdlog";
+    license = licenses.mit;
+    maintainers = with maintainers; [ obadz ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
Reverts mc-rtc/nixpkgs#20

Sry I messed up with mergify configuration and it merged before ci checks completed, and there was an issue with mc_rtc_rviz_panel. To prevent the cache from being stale, it's reverted for now, fixing the issue in #25 