### PR TITLE
mkFlakoboros and flakeModule with optional arguments

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,22 +53,45 @@
           inputs.flake-parts.lib.importApply ./module.nix (
             {
               inherit (inputs) gepetto jrl-cmakemodulesv2;
+              lib = inputs.nixpkgs.lib;
             }
             // attrs
           );
         # Convenience module that enables the private overlay
         flakeModulePrivate = flakeModule { enablePrivateOverlay = true; };
+
+        # mkFlakoboros
+        #   Usage: mkFlakoboros { localInputs, localFlakeModule ? flakeModule } flakoborosModule
+        #   - localInputs:        Flake inputs set.
+        #   - localFlakeModule:   (Optional) Flake module to use (defaults to flakeModule).
+        #   - flakoborosModule:   Flake-parts module (function of args).
+        #                         See: https://gepetto.github.io/flakoboros/index.html
+        #
+        #   Example:
+        #     outputs = inputs:
+        #       mkFlakoboros { localInputs = inputs; } ({ lib, ... }: {
+        #         config = { };
+        #       })
+        #
+        #     # With custom flake module:
+        #     outputs = inputs:
+        #       mkFlakoboros {
+        #         localInputs = inputs;
+        #         localFlakeModule = flakeModule { with-ros = false; };
+        #       } ({ lib, ... }: {
+        #         config = { };
+        #       })
         mkFlakoboros =
           {
             localInputs,
             localFlakeModule ? flakeModule,
           }:
-          module:
+          flakoborosModule:
           inputs.flake-parts.lib.mkFlake { inputs = localInputs; } (args: {
             systems = import inputs.systems;
             imports = [
               localFlakeModule
-              { flakoboros = builtins.trace "called" (module args); }
+              { flakoboros = flakoborosModule args; }
             ];
           });
       in
@@ -86,28 +109,32 @@
           #   Description: Creates a flake using the default flakeModule (public, with-ros).
           #   Arguments:
           #     - localInputs: The flake inputs set.
-          #     - module: The flake-parts module to use.
-          lib.mkFlakoboros = localInputs: module: mkFlakoboros { inherit localInputs; } module;
+          #     - flakoborosModule: The flake-parts module to use.
+          #                         See https://gepetto.github.io/flakoboros/index.html
+          lib.mkFlakoboros =
+            localInputs: flakoborosModule: mkFlakoboros { inherit localInputs; } flakoborosModule;
 
           # lib.mkFlakoborosPrivate
           #   Usage: lib.mkFlakoborosPrivate localInputs module
           #   Description: Creates a flake using the private flakeModulePrivate (private, with-ros).
           #   Arguments:
           #     - localInputs: The flake inputs set.
-          #     - module: The flake-parts module to use.
+          #     - flakoborosModule: The flake-parts module to use.
+          #                         See https://gepetto.github.io/flakoboros/index.html
           lib.mkFlakoborosPrivate =
-            localInputs: module:
+            localInputs: flakoborosModule:
             mkFlakoboros {
               inherit localInputs;
               localFlakeModule = flakeModulePrivate;
-            } module;
+            } flakoborosModule;
           # lib.mkFlakoborosCustom
           #   Usage: lib.mkFlakoborosCustom localInputs localFlakeModule module
           #   Description: Creates a flake using a custom flake module (pass arguments to mc-rtc's nixpkgs flake module).
           #   Arguments:
           #     - localInputs: The flake inputs set.
           #     - localFlakeModule: The flake module to use.
-          #     - module: The flake-parts module to use.
+          #     - flakoborosModule: The flake-parts module to use.
+          #                         See https://gepetto.github.io/flakoboros/index.html
           # Example:
           # outputs = inputs:
           #   inputs.mc-rtc-nix.lib.mkFlakoborosCustom
@@ -120,8 +147,8 @@
           #       }
           #     })
           lib.mkFlakoborosCustom =
-            localInputs: localFlakeModule: module:
-            mkFlakoboros { inherit localInputs localFlakeModule; } module;
+            localInputs: localFlakeModule: flakoborosModule:
+            mkFlakoboros { inherit localInputs localFlakeModule; } flakoborosModule;
 
           templates = {
             default = {

--- a/flake.nix
+++ b/flake.nix
@@ -30,31 +30,99 @@
     inputs.flake-parts.lib.mkFlake { inherit inputs; } (
       { ... }:
       let
-        flakeModule = inputs.flake-parts.lib.importApply ./module.nix {
-          inherit (inputs) gepetto jrl-cmakemodulesv2;
-        };
+        # flakeModule = inputs.flake-parts.lib.importApply ./module.nix {
+        #   inherit (inputs) gepetto jrl-cmakemodulesv2;
+        # };
+        # flakeModule = {enablePrivateOverlay ? false} :
+        #   inputs.flake-parts.lib.importApply ./module.nix {
+        #     inherit (inputs) gepetto jrl-cmakemodulesv2 enablePrivateOverlay;
+        #   };
 
+        # exports a flakeModule to be imported in other flakes
+        # arg: can either be:
+        #   - nothing: default arguments (public flake, with ros)
+        #   - or an attribute set with:
+        #       enablePrivateOverlay: whether to enable the private overlay (default: false)
+        #       with-ros: whether to build the packages in the overlay with ROS support (default: true)
+        #                 e.g that is robot description packages, mc-rtc, etc
+        flakeModule =
+          arg:
+          let
+            attrs = if builtins.isAttrs arg then arg else { };
+          in
+          inputs.flake-parts.lib.importApply ./module.nix (
+            {
+              inherit (inputs) gepetto jrl-cmakemodulesv2;
+            }
+            // attrs
+          );
+        # Convenience module that enables the private overlay
+        flakeModulePrivate = flakeModule { enablePrivateOverlay = true; };
+        mkFlakoboros =
+          {
+            localInputs,
+            localFlakeModule ? flakeModule,
+          }:
+          module:
+          inputs.flake-parts.lib.mkFlake { inputs = localInputs; } (args: {
+            systems = import inputs.systems;
+            imports = [
+              localFlakeModule
+              { flakoboros = builtins.trace "called" (module args); }
+            ];
+          });
       in
       {
         systems = import inputs.systems;
-        # systems =
-        # [
-        #   "x86_64-linux"
-        # ];
         imports = [
-          flakeModule
+          (flakeModule { })
         ];
         flake = {
           inherit flakeModule;
-          lib.mkFlakoboros =
+          inherit flakeModulePrivate;
+
+          # lib.mkFlakoboros
+          #   Usage: lib.mkFlakoboros localInputs module
+          #   Description: Creates a flake using the default flakeModule (public, with-ros).
+          #   Arguments:
+          #     - localInputs: The flake inputs set.
+          #     - module: The flake-parts module to use.
+          lib.mkFlakoboros = localInputs: module: mkFlakoboros { inherit localInputs; } module;
+
+          # lib.mkFlakoborosPrivate
+          #   Usage: lib.mkFlakoborosPrivate localInputs module
+          #   Description: Creates a flake using the private flakeModulePrivate (private, with-ros).
+          #   Arguments:
+          #     - localInputs: The flake inputs set.
+          #     - module: The flake-parts module to use.
+          lib.mkFlakoborosPrivate =
             localInputs: module:
-            inputs.flake-parts.lib.mkFlake { inputs = localInputs; } (args: {
-              systems = import inputs.systems;
-              imports = [
-                flakeModule
-                { flakoboros = module args; }
-              ];
-            });
+            mkFlakoboros {
+              inherit localInputs;
+              localFlakeModule = flakeModulePrivate;
+            } module;
+          # lib.mkFlakoborosCustom
+          #   Usage: lib.mkFlakoborosCustom localInputs localFlakeModule module
+          #   Description: Creates a flake using a custom flake module (pass arguments to mc-rtc's nixpkgs flake module).
+          #   Arguments:
+          #     - localInputs: The flake inputs set.
+          #     - localFlakeModule: The flake module to use.
+          #     - module: The flake-parts module to use.
+          # Example:
+          # outputs = inputs:
+          #   inputs.mc-rtc-nix.lib.mkFlakoborosCustom
+          #     inputs
+          #     (flakeModule { with-ros = false; })
+          #     ({ lib, ... }: {
+          #       # your flakoboros module here
+          #       overrideAttrs.package = {
+          #         src = lib.cleanSource ./.;
+          #       }
+          #     })
+          lib.mkFlakoborosCustom =
+            localInputs: localFlakeModule: module:
+            mkFlakoboros { inherit localInputs localFlakeModule; } module;
+
           templates = {
             default = {
               path = ./templates/default;

--- a/module.nix
+++ b/module.nix
@@ -2,17 +2,19 @@
   gepetto,
   jrl-cmakemodulesv2,
   enablePrivateOverlay ? false,
+  with-ros ? true,
   ...
 }:
 {
-  lib,
   self,
   ...
 }:
 let
   privateOverlay =
     if enablePrivateOverlay then
-      builtins.trace "Enabling private overlay" (final: prev: import ./overlay-private.nix { } final prev)
+      builtins.trace "Enabling private overlay" (
+        final: prev: import ./overlay-private.nix { inherit with-ros; } final prev
+      )
     else
       (_: _: { });
 in
@@ -21,9 +23,7 @@ in
 
   config = {
     flake.overlays.mc-rtc-pkgs = import ./overlay.nix {
-      inherit lib;
-      inherit jrl-cmakemodulesv2;
-      with-ros = true;
+      inherit with-ros;
     };
     flake.overlays.mc-rtc-private = privateOverlay;
     flakoboros.overlays = [

--- a/module.nix
+++ b/module.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   gepetto,
   jrl-cmakemodulesv2,
   enablePrivateOverlay ? false,
@@ -12,24 +13,30 @@
 let
   privateOverlay =
     if enablePrivateOverlay then
-      builtins.trace "Enabling private overlay" (
+      builtins.trace "mc-rtc-nix: importing private overlay (with-ros: ${lib.boolToString with-ros})" (
         final: prev: import ./overlay-private.nix { inherit with-ros; } final prev
       )
     else
-      (_: _: { });
+      builtins.trace
+        "mc-rtc-nix: private overlay is disabled, using an empty overlay (enablePrivateOverlay: ${lib.boolToString enablePrivateOverlay})"
+        (_: _: { });
 in
 {
-  imports = [ gepetto.flakeModule ];
+  imports = [ (builtins.trace "mc-rtc-nix: importing gepetto's flake module" gepetto.flakeModule) ];
 
   config = {
-    flake.overlays.mc-rtc-pkgs = import ./overlay.nix {
-      inherit with-ros;
-    };
+    flake.overlays.mc-rtc-pkgs = import ./overlay.nix (
+      builtins.trace "mc-rtc-nix: importing public overlay (with-ros: ${lib.boolToString with-ros})" {
+        inherit with-ros;
+      }
+    );
     flake.overlays.mc-rtc-private = privateOverlay;
     flakoboros.overlays = [
-      self.overlays.mc-rtc-pkgs
-      self.overlays.mc-rtc-private
-      (_final: prev: { jrl-cmakemodulesv2 = jrl-cmakemodulesv2.packages.${prev.system}.default; })
+      (builtins.trace "mc-rtc-nix: importing overlay mc-rtc-pkgs" self.overlays.mc-rtc-pkgs)
+      (builtins.trace "mc-rtc-nix: importing overlay mc-rtc-private (enablePrivateOverlay: ${lib.boolToString enablePrivateOverlay})" self.overlays.mc-rtc-private)
+      (builtins.trace "mc-rtc-nix: importing overlay for jrl-cmakemodulesv2" (
+        _final: prev: { jrl-cmakemodulesv2 = jrl-cmakemodulesv2.packages.${prev.system}.default; }
+      ))
     ];
     # Set permittedInsecurePackages for all pkgs instances
     flakoboros.nixpkgsConfig = {

--- a/private/flake.nix
+++ b/private/flake.nix
@@ -33,6 +33,7 @@
       let
         flakeModulePrivate = inputs.flake-parts.lib.importApply ../module.nix {
           inherit (inputs) gepetto jrl-cmakemodulesv2;
+          lib = inputs.nixpkgs.lib;
           enablePrivateOverlay = true;
         };
       in


### PR DESCRIPTION
mkFlakoboros and flakeModule with optional args
Adds:
```
flakeModule with optional attribute set use:
  flakeModule { enablePrivateOverlay = true; with-ros = true;}
  flakeModule {}
  flakeModule
```

mkFlakoboros with optional flakeModule as argument
```
  lib.mkFlakoboros inputs flakoborosModule # as before
  lib.mkFlakoborosPrivate inputs module # convenience function with the
private overlay
  lib.mkFlakoborosCustom inputs (flakeModule { with-ros = false; })
flakoborosModule
```

Example use

```nix
{
  description = "fmt torture test for mc-rtc types";
  inputs.mc-rtc-nix.url = "github:mc-rtc/nixpkgs";

  outputs =
    inputs:
    # inputs.mc-rtc-nix.lib.mkFlakoboros inputs (
    # inputs.mc-rtc-nix.lib.mkFlakoborosPrivate inputs (
    inputs.mc-rtc-nix.lib.mkFlakoborosCustom inputs (inputs.mc-rtc-nix.flakeModule { enablePrivateOverlay = true; with-ros = false; }) (
      { lib, ... }:
      {
         packages = {...}
         # all flakoboros options
      }
```