### PR TITLE
Move jrl-cmakemodules to buildInputs

### DIFF
--- a/pkgs/3rd-party/imguizmo.nix
+++ b/pkgs/3rd-party/imguizmo.nix
@@ -27,9 +27,11 @@ stdenv.mkDerivation (_finalAttrs: {
       hash = "sha256-JLwciNGo90vR5tsFB4z5JPvhCz38FhN9Ja/5+Ct6YPo=";
     };
 
+  buildInputs = [
+    jrl-cmakemodules
+  ];
   nativeBuildInputs = [
     cmake
-    jrl-cmakemodules
   ];
   propagatedBuildInputs = [
     imgui

--- a/pkgs/mc-rtc/controllers/polytopeController/mc-dynamic-polytopes.nix
+++ b/pkgs/mc-rtc/controllers/polytopeController/mc-dynamic-polytopes.nix
@@ -34,9 +34,11 @@ stdenv.mkDerivation (_finalAttrs: {
       hash = "";
     };
 
+  buildInputs = [
+    jrl-cmakemodules
+  ];
   nativeBuildInputs = [
     cmake
-    jrl-cmakemodules
   ];
   propagatedBuildInputs = [
     mc-rtc

--- a/pkgs/mc-rtc/mc-mujoco/default.nix
+++ b/pkgs/mc-rtc/mc-mujoco/default.nix
@@ -40,10 +40,12 @@ stdenv.mkDerivation (_finalAttrs: {
     hash = "sha256-GDJKEOyRjPF5eTpXA7x82K86fjLyx3N3eTt2ZSmcYv4=";
   };
 
-  buildInputs = [ cli11 ];
+  buildInputs = [
+    cli11
+    jrl-cmakemodules
+  ];
   nativeBuildInputs = [
     cmake
-    jrl-cmakemodules
     makeWrapper
   ];
   propagatedBuildInputs = [

--- a/pkgs/mc-rtc/mc-rtc.nix
+++ b/pkgs/mc-rtc/mc-rtc.nix
@@ -56,10 +56,12 @@ in
     else
       "";
 
+  buildInputs = [
+    jrl-cmakemodules
+  ];
   nativeBuildInputs = [
     cmake
     pkg-config
-    jrl-cmakemodules
     qt5.wrapQtAppsHook
     python3Packages.distutils
     python3Packages.pytest

--- a/pkgs/mesh-sampling/default.nix
+++ b/pkgs/mesh-sampling/default.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchgit,
+  fetchFromGitHub,
   cmake,
   jrl-cmakemodules,
   gtest,
@@ -14,16 +14,14 @@
 
 stdenv.mkDerivation {
   pname = "mesh-sampling";
-  version = "1.0.0";
+  version = "1.1.0";
 
-  src =
-    # TODO: release mesh-sampling
-    fetchgit {
-      url = "https://github.com/jrl-umi3218/mesh_sampling";
-      # master
-      rev = "466064a4e9b7718b0b90922122c6aedd4867724a";
-      sha256 = "sha256-2e1Ctq/2lj2BNyxPH3VD+owYlURyIUq82D74y4nKPeg=";
-    };
+  src = fetchFromGitHub {
+    owner = "jrl-umi3218";
+    repo = "mesh_sampling";
+    tag = "v1.1.0";
+    hash = "sha256-hZ8v42g0+Kw0aQtOa9id8WQ/pwDMpn8QxxBXVXpPpJU=";
+  };
 
   buildInputs = [
     cli11

--- a/pkgs/mesh-sampling/default.nix
+++ b/pkgs/mesh-sampling/default.nix
@@ -3,9 +3,11 @@
   lib,
   fetchgit,
   cmake,
+  jrl-cmakemodules,
+  gtest,
+  cli11,
   qhull,
   assimp,
-  cli11,
   eigen,
   libz,
 }:
@@ -23,9 +25,13 @@ stdenv.mkDerivation {
       sha256 = "sha256-2e1Ctq/2lj2BNyxPH3VD+owYlURyIUq82D74y4nKPeg=";
     };
 
+  buildInputs = [
+    cli11
+    jrl-cmakemodules
+  ];
   nativeBuildInputs = [
     cmake
-    cli11
+    gtest
   ];
   # XXX why is libz dependency manually required here? Either qhull or assimp should bring it
   propagatedBuildInputs = [
@@ -39,9 +45,10 @@ stdenv.mkDerivation {
     "-DINSTALL_DOCUMENTATION=OFF"
   ];
 
-  doCheck = false;
+  doCheck = true;
 
   meta = with lib; {
+    mainProgram = "mesh_sampling";
     description = "Samplers to obtain pointclouds from CAD meshes ";
     homepage = "https://github.com/jrl-umi3218/mesh_sampling";
     license = licenses.bsd2;

--- a/pkgs/spacevecalg/default.nix
+++ b/pkgs/spacevecalg/default.nix
@@ -22,9 +22,11 @@ stdenv.mkDerivation {
     hash = "sha256-fTKKj3m8cO4F46LlO7r8JeuWLhlyRcX7EblHroDYFkQ=";
   };
 
+  buildInputs = [
+    jrl-cmakemodules
+  ];
   nativeBuildInputs = [
     cmake
-    jrl-cmakemodules
     pkg-config
     doxygen
     python3Packages.cython

--- a/pkgs/tasks/default.nix
+++ b/pkgs/tasks/default.nix
@@ -23,9 +23,11 @@ stdenv.mkDerivation {
     hash = "sha256-1XrRagwiMJwukbqPmlJCzp/Y11POdUdDIFjeZTCg3Ik=";
   };
 
+  buildInputs = [
+    jrl-cmakemodules
+  ];
   nativeBuildInputs = [
     cmake
-    jrl-cmakemodules
     python3Packages.distutils
     python3Packages.pytest
     python3Packages.cython

--- a/pkgs/tvm/default.nix
+++ b/pkgs/tvm/default.nix
@@ -20,9 +20,11 @@ stdenv.mkDerivation {
     sha256 = "sha256-qse7emorGWqoWlmzaHNdbDiHFXrVOo3oz8Fah4AYmL8=";
   };
 
+  buildInputs = [
+    jrl-cmakemodules
+  ];
   nativeBuildInputs = [
     cmake
-    jrl-cmakemodules
   ];
   propagatedBuildInputs = [
     eigen-qld


### PR DESCRIPTION
- **treewide(jrl-cmakemodules): is a buildInputs**
- **mesh-sampling: release v1.1.0**
