### PR TITLE
Fix ros-free build (with-ros=false)

### DIFF
--- a/.github/workflows/nix-variants-private.yml
+++ b/.github/workflows/nix-variants-private.yml
@@ -82,7 +82,7 @@ jobs:
           token: ${{ secrets.ATTIC_TOKEN }}
       - &setup-ccache-env
         name: Setup ccache environment
-        if: ${{ matrix.variant == 'private-ccache' }}
+        if: ${{ matrix.ccache == true }}
         run: |
           sudo mkdir -m0770 -p '/var/cache/ccache'
           sudo chown --reference=/nix/store '/var/cache/ccache'

--- a/.github/workflows/nix-variants-private.yml
+++ b/.github/workflows/nix-variants-private.yml
@@ -12,20 +12,16 @@ on:
       - main
 jobs:
   populate-cache:
-    # - This condition allows the job to run if:
-    #   - The workflow is not triggered by a pull request (`github.event_name != 'pull_request'`), or
-    #   - The PR's source repo is the same as the base repo.
-    # This is done to make sure that the required secrets are available to the CI
     if: github.event_name != 'pull_request' || github.repository == github.event.pull_request.head.repo.full_name
-    name: "${{matrix.variant}}: ${{ matrix.build }} on ${{ matrix.os }}"
+    name: "private-${{ matrix.ccache == true && 'ccache' || 'no-ccache' }}-${{ matrix.ros == true && 'ros' || 'ros-free' }}: ${{ matrix.build }} on ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
     strategy:
       fail-fast: false
       matrix: &matrix
         os: [ubuntu-24.04]
-        variant:
-          - "private"
-          - "private-ccache"
+        private: [true] # Kept as a matrix item for easy flagging
+        ccache: [true, false]
+        ros: [true, false]
         build:
           - "devShells.x86_64-linux.mc-rtc-superbuild-minimal"
           - "devShells.x86_64-linux.mc-rtc-superbuild-default"
@@ -35,14 +31,29 @@ jobs:
       - name: "Determine Variant Arguments"
         id: flags
         run: |
-          if [ "${{ matrix.variant }}" = "private" ]; then
-            echo "args=--override-input private-trigger github:boolean-option/true" >> "$GITHUB_OUTPUT"
-          elif [ "${{ matrix.variant }}" = "private-ccache" ]; then
-            echo "args=--override-input private-trigger github:boolean-option/true --override-input ccache-trigger github:boolean-option/true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Unsupported variant: ${{ matrix.variant }}"
-            exit 42
+          ARGS=""
+          
+          # Private trigger is always true for this matrix dimension
+          if [ "${{ matrix.private }}" = "true" ]; then
+            ARGS="$ARGS --override-input private-trigger github:boolean-option/true"
           fi
+          
+          # Handle ccache trigger
+          if [ "${{ matrix.ccache }}" = "true" ]; then
+            ARGS="$ARGS --override-input ccache-trigger github:boolean-option/true"
+          else
+            ARGS="$ARGS --override-input ccache-trigger github:boolean-option/false"
+          fi
+          
+          # Handle ros trigger
+          if [ "${{ matrix.ros }}" = "true" ]; then
+            ARGS="$ARGS --override-input with-ros-trigger github:boolean-option/true"
+          else
+            ARGS="$ARGS --override-input with-ros-trigger github:boolean-option/false"
+          fi
+          
+          # Trim leading space and export
+          echo "args=$(echo "$ARGS" | xargs)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v6
       # Configures ssh-agent if SSH_KEY secret exists
       - &confiure-ssh-agent

--- a/.github/workflows/nix-variants-public.yml
+++ b/.github/workflows/nix-variants-public.yml
@@ -14,7 +14,7 @@ jobs:
     #   - The PR's source repo is the same as the base repo.
     # This is done to make sure that the required secrets are available to the CI
     if: github.event_name != 'pull_request' || github.repository == github.event.pull_request.head.repo.full_name
-    name: "${{ matrix.build }} (ccache: ${{ matrix.ccache }}, ros: ${{ matrix.ros }}) on ${{ matrix.os }}"
+    name: "public-${{ matrix.ccache == true && 'ccache' || 'no-ccache' }}-${{ matrix.ros == true && 'ros' || 'ros-free' }}: ${{ matrix.build }} on ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
     strategy:
       fail-fast: false

--- a/.github/workflows/nix-variants-public.yml
+++ b/.github/workflows/nix-variants-public.yml
@@ -14,13 +14,14 @@ jobs:
     #   - The PR's source repo is the same as the base repo.
     # This is done to make sure that the required secrets are available to the CI
     if: github.event_name != 'pull_request' || github.repository == github.event.pull_request.head.repo.full_name
-    name: "${{matrix.variant}}: ${{ matrix.build }} on ${{ matrix.os }}"
+    name: "${{ matrix.build }} (ccache: ${{ matrix.ccache }}, ros: ${{ matrix.ros }}) on ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
     strategy:
       fail-fast: false
       matrix: &matrix
         os: [ubuntu-24.04]
-        variant: [ "ccache" ]
+        ccache: [true, false]
+        ros: [true, false]
         build:
           - "devShells.x86_64-linux.mc-rtc-superbuild-minimal"
           - "devShells.x86_64-linux.mc-rtc-superbuild-default"
@@ -30,12 +31,24 @@ jobs:
       - name: "Determine Variant Arguments"
         id: flags
         run: |
-          if [ "${{ matrix.variant }}" = "ccache" ]; then
-            echo "args=--override-input ccache-trigger github:boolean-option/true" >> "$GITHUB_OUTPUT"
+          ARGS=""
+          
+          # Handle ccache trigger
+          if [ "${{ matrix.ccache }}" = "true" ]; then
+            ARGS="$ARGS --override-input ccache-trigger github:boolean-option/true"
           else
-            echo "Unsupported variant: ${{ matrix.variant }}"
-            exit 42
+            ARGS="$ARGS --override-input ccache-trigger github:boolean-option/false"
           fi
+          
+          # Handle ros trigger (ros-free is the inverse of with-ros)
+          if [ "${{ matrix.ros }}" = "true" ]; then
+            ARGS="$ARGS --override-input with-ros-trigger github:boolean-option/true"
+          else
+            ARGS="$ARGS --override-input with-ros-trigger github:boolean-option/false"
+          fi
+          
+          # Trim leading space and export
+          echo "args=$(echo "$ARGS" | xargs)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
       - &cachix-step

--- a/.superbuild/mc_rtc.yaml
+++ b/.superbuild/mc_rtc.yaml
@@ -1,9 +1,0 @@
----
-
-
-
-ControllerModulePaths: []
-RobotModulePaths: []
-ObserverModulePaths: []
-GlobalPluginPaths: []
-LoadUserConfiguration: false

--- a/flake.lock
+++ b/flake.lock
@@ -957,7 +957,8 @@
         "systems": [
           "gepetto",
           "systems"
-        ]
+        ],
+        "with-ros-trigger": "with-ros-trigger"
       }
     },
     "rosdistro": {
@@ -1247,6 +1248,21 @@
       "original": {
         "owner": "pyproject-nix",
         "repo": "uv2nix",
+        "type": "github"
+      }
+    },
+    "with-ros-trigger": {
+      "locked": {
+        "lastModified": 1657739253,
+        "narHash": "sha256-L9eyTL7njtPBUYmZRYFKCzQFDgua9U9oE7UwCzjZfl8=",
+        "owner": "boolean-option",
+        "repo": "true",
+        "rev": "6ecb49143ca31b140a5273f1575746ba93c3f698",
+        "type": "github"
+      },
+      "original": {
+        "owner": "boolean-option",
+        "repo": "true",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
     # Use as nix build . --override-input private-trigger github:boolean-option/true
     private-trigger.url = "github:boolean-option/false";
     ccache-trigger.url = "github:boolean-option/false";
+    with-ros-trigger.url = "github:boolean-option/true";
   };
 
   nixConfig = {
@@ -38,7 +39,11 @@
       flakeModule = inputs.flake-parts.lib.importApply ./module.nix {
         inherit (inputs) gepetto jrl-cmakemodulesv2 make-shell;
       };
-      buildPrivate = inputs.private-trigger.value or false;
+      inputTriggers = {
+        buildPrivate = inputs.private-trigger.value or false;
+        with-ros = inputs.with-ros-trigger.value or true;
+        ccache = inputs.ccache-trigger.value or false;
+      };
 
       mkFlakoboros =
         {
@@ -61,10 +66,12 @@
         {
           mc-rtc-nix = {
             packages = true;
+            with-ros = inputTriggers.with-ros;
             # gepetto.packages = true;
             # gepetto.devShells = true;
             overlays = {
-              private = buildPrivate;
+              private = inputTriggers.buildPrivate;
+              ccache = inputTriggers.ccache;
             };
           };
           mc-rtc-superbuild = {

--- a/module.nix
+++ b/module.nix
@@ -146,10 +146,14 @@
                 robots = [
                   pkgs.mc-g1
                   pkgs.mc-h1
+                ]
+                ++ lib.optionals (!pkgs.stdenv.hostPlatform.isDarwin) [
+                  # FIXME: macos support
+                  pkgs.mc-panda
+                  pkgs.mc-panda-lirmm
+                ]
+                ++ lib.optionals cfg.with-ros [
                   pkgs.mc-ur5e
-                  # FIXME: disabled until merged and compatible with macos
-                  # pkgs.mc-panda
-                  # pkgs.mc-panda-lirmm
                 ]
                 ++ lib.optionals cfg.overlays.private [
                   pkgs.mc-hrp2
@@ -284,6 +288,12 @@
                 mc-ur5e
                 mc-panda
                 mc-panda-lirmm
+                ;
+
+              # Robot description
+              inherit (pkgs)
+                mc-int-obj-description
+                jvrc-description
                 ;
 
               # MuJoCo Robots

--- a/pkgs/mc-rtc-data/default.nix
+++ b/pkgs/mc-rtc-data/default.nix
@@ -91,9 +91,11 @@ else
     propagatedBuildInputs = map (d: d.drv) deps;
     buildInputs = [ ];
     nativeBuildInputs = [ ];
-    installPhase = ''
-      mkdir -p $out
-    '';
+    dontUnpack = true;
+    dontInstall = true;
+    # installPhase = ''
+    #   mkdir -p $out
+    # '';
     meta = with lib; {
       description = "Metapackage for mc-rtc data (envs, objects, etc)";
       homepage = "https://github.com/jrl-umi3218/mc_rtc_data";

--- a/pkgs/mc-rtc-data/jvrc-description.nix
+++ b/pkgs/mc-rtc-data/jvrc-description.nix
@@ -34,6 +34,7 @@ in
   '';
 
   cmakeFlags = [
+    (lib.cmakeBool "DISABLE_ROS" (!with-ros))
   ];
 
   doCheck = true;

--- a/pkgs/mc-rtc-data/mc-env-description.nix
+++ b/pkgs/mc-rtc-data/mc-env-description.nix
@@ -30,8 +30,8 @@ in
       builtins.trace "with-ros false: ${toString with-ros}" (fetchgit {
         # master
         url = "https://github.com/jrl-umi3218/mc_env_description";
-        rev = "ca84a40a0a27783c4ed63bd8f057af7ef41b33bb";
-        sha256 = "sha256-ntz/u9YTWd2YuVhtRngm0qnOU8nsH0ODZ828x/Uba9s=";
+        rev = "b55cddfead7a43217d5b179a6eca213ad94f4e65";
+        sha256 = "sha256-5sjyojlG+MM4OCUmNSlEhu7FLvckk2n7oE8mFu9H7Sw=";
         fetchSubmodules = true;
       });
 
@@ -43,6 +43,7 @@ in
   '';
 
   cmakeFlags = [
+    (lib.cmakeBool "DISABLE_ROS" (!with-ros))
     "-DROS_VERSION=2"
     "-DBUILD_TESTING=OFF"
     "-DPYTHON_BINDING=OFF"

--- a/pkgs/mc-rtc-data/mc-int-obj-description.nix
+++ b/pkgs/mc-rtc-data/mc-int-obj-description.nix
@@ -35,6 +35,7 @@ in
   '';
 
   cmakeFlags = [
+    (lib.cmakeBool "DISABLE_ROS" (!with-ros))
     "-DROS_VERSION=2"
     "-DBUILD_TESTING=OFF"
     "-DPYTHON_BINDING=OFF"

--- a/pkgs/mc-rtc-imgui/default.nix
+++ b/pkgs/mc-rtc-imgui/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   cmake,
   jrl-cmakemodules,
+  pkg-config,
   mc-rtc,
   imgui,
   implot,
@@ -26,6 +27,7 @@ stdenv.mkDerivation (_finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    pkg-config
     jrl-cmakemodules
   ];
   propagatedBuildInputs = [

--- a/pkgs/mc-rtc-magnum/standalone.nix
+++ b/pkgs/mc-rtc-magnum/standalone.nix
@@ -4,6 +4,7 @@
   makeWrapper,
   fetchFromGitHub,
   cmake,
+  pkg-config,
   mc-rtc-imgui,
   magnum-with-plugins,
   imguizmo,
@@ -18,8 +19,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "mc-rtc";
     repo = "mc_rtc-magnum";
-    rev = "a700fedc432bf1c453f6e13a26fc7dfd8f38ff78";
-    hash = "sha256-NvIFuR31Niy+NhIkeW6yQCgQkydBc+JFeIVp5nszpc0=";
+    rev = "ede3e81fc2eafce633821718ed52b386cdd7671b";
+    hash = "sha256-tZN1qwxHYfJb9jEWwv6PWxO+LTVkoGBZLkjdDhFDS+I=";
   };
 
   nativeBuildInputs = [
@@ -28,6 +29,7 @@ stdenv.mkDerivation {
   ];
   dontBuild = true;
   buildInputs = [
+    pkg-config
     mc-rtc-imgui
     # magnum
     # magnum-integration

--- a/pkgs/mc-rtc/mc-mujoco/default.nix
+++ b/pkgs/mc-rtc/mc-mujoco/default.nix
@@ -5,6 +5,7 @@
   makeWrapper,
   mc-mujoco-robots,
   cmake,
+  pkg-config,
   jrl-cmakemodules,
   cli11,
   mc-rtc,
@@ -43,6 +44,7 @@ stdenv.mkDerivation (_finalAttrs: {
   buildInputs = [
     cli11
     jrl-cmakemodules
+    pkg-config
   ];
   nativeBuildInputs = [
     cmake

--- a/pkgs/mc-rtc/mc-rtc.nix
+++ b/pkgs/mc-rtc/mc-rtc.nix
@@ -61,7 +61,6 @@ in
   ];
   nativeBuildInputs = [
     cmake
-    pkg-config
     qt5.wrapQtAppsHook
     python3Packages.distutils
     python3Packages.pytest
@@ -75,6 +74,7 @@ in
   ];
 
   propagatedBuildInputs = [
+    pkg-config
     tasks
     eigen-quadprog
     libtool
@@ -124,6 +124,14 @@ in
 
   postInstall = ''
     wrapQtApp $out/bin/mc_log_ui
+  '';
+
+  # XXX: Without this fixupPhase fails due to RPATHS references to /build/
+  preFixup = ''
+    find "$out/${python3Packages.python.sitePackages}" -name "*.so" -type f | while read -r binary; do
+      echo "Shrinking RPATH for $binary"
+      patchelf --shrink-rpath --allowed-rpath-prefixes "$NIX_STORE" "$binary"
+    done
   '';
 
   meta = with lib; {

--- a/pkgs/mc-rtc/observers/mc-state-observation/default.nix
+++ b/pkgs/mc-rtc/observers/mc-state-observation/default.nix
@@ -3,6 +3,7 @@
   lib,
   fetchurl,
   cmake,
+  pkg-config,
   mc-rtc,
   tf2-eigen,
   with-ros ? false,
@@ -22,7 +23,10 @@ in
     sha256 = "sha256-F1LzhAK0MQM4mc5+dr0lK364J7f0nA1ZBe1RZlG3Pmo=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
   propagatedBuildInputs = [ mc-rtc ] ++ lib.optional (with-ros && tf2-eigen != null) tf2-eigen;
 
   # This requirement implies < 2.0 but in fact it's fine for this one

--- a/pkgs/mc-rtc/plugins/mc-force-shoe-plugin.nix
+++ b/pkgs/mc-rtc/plugins/mc-force-shoe-plugin.nix
@@ -3,6 +3,7 @@
   lib,
   fetchFromGitHub,
   cmake,
+  pkg-config,
   mc-rtc,
   socat,
   picocom,
@@ -23,6 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-mgtuJ0rmFKSgtth+/uVnvIJvXY7Ij8veywQ7Fm1neyk=";
     };
 
+  buildInputs = [ pkg-config ];
   nativeBuildInputs = [ cmake ];
   propagatedBuildInputs = [
     mc-rtc

--- a/pkgs/mc-rtc/plugins/mc-robot-model-update.nix
+++ b/pkgs/mc-rtc/plugins/mc-robot-model-update.nix
@@ -3,6 +3,7 @@
   lib,
   fetchFromGitHub,
   cmake,
+  pkg-config,
   mc-rtc,
 }:
 
@@ -19,6 +20,7 @@ stdenv.mkDerivation (_finalAttrs: {
     hash = "sha256-/gvwqy73elA6gUppwd7OSp0jkojHZUDZGUJlAVnkodU=";
   };
 
+  buildInputs = [ pkg-config ];
   nativeBuildInputs = [ cmake ];
   propagatedBuildInputs = [
     mc-rtc

--- a/pkgs/mc-rtc/robots/descriptions/hrp5-p-description.nix
+++ b/pkgs/mc-rtc/robots/descriptions/hrp5-p-description.nix
@@ -26,6 +26,7 @@
   '';
 
   cmakeFlags = [
+    (lib.cmakeBool "DISABLE_ROS" (!with-ros))
     "-DBUILD_TESTING=OFF"
   ];
 

--- a/pkgs/mc-rtc/robots/descriptions/ur5e-description.nix
+++ b/pkgs/mc-rtc/robots/descriptions/ur5e-description.nix
@@ -30,7 +30,9 @@
     export ROS_VERSION=2
   '';
 
-  cmakeFlags = lib.optional (!with-ros) "-DDISABLE_ROS=ON" ++ [
+  cmakeFlags = [
+    (lib.cmakeBool "DISABLE_ROS" (!with-ros))
+    "-DROS_VERSION=0" # FIXME: this version does not have DISABLE_ROS flag
     "-DBUILD_TESTING=OFF"
   ];
 

--- a/pkgs/mc-rtc/robots/mc-panda/libfranka.nix
+++ b/pkgs/mc-rtc/robots/mc-panda/libfranka.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation {
     description = "C++ library for Franka Robotics research robots";
     homepage = "https://github.com/frankarobotics/libfranka";
     license = licenses.asl20;
-    platforms = platforms.linux;
+    # platforms = platforms.linux;
     maintainers = [ ];
   };
 }


### PR DESCRIPTION
Makes

```
nix develop --override-input private-trigger github:boolean-option/true --override-input with-ros-trigger github:boolean-option/false .#mc-rtc-superbuild-full
```

work as expected, without any ros dependency.

TODO: consider support for a ros-free UR5 description.