### PR TITLE
Qt: synchronize qt version with flakboros' one derived from rosDistro

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -204,11 +204,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1781324212,
-        "narHash": "sha256-lqIEMqeuJ450S7JdWTo8JjF3YlahGNR2FCz/AlA9ZhM=",
+        "lastModified": 1782042109,
+        "narHash": "sha256-oDCl/rcvJVTcf6G2ag3YdZSMHDVBBmoXTysY5yzq+Dk=",
         "owner": "gepetto",
         "repo": "flakoboros",
-        "rev": "78aa318051a5345d82931df66c5c8d0844edcb2a",
+        "rev": "fc7d44063fa05f1a78c97c63b124c1da2862331c",
         "type": "github"
       },
       "original": {
@@ -277,6 +277,12 @@
         ],
         "pyproject-build-systems": "pyproject-build-systems",
         "pyproject-nix": "pyproject-nix",
+        "rosdistro": [
+          "gepetto",
+          "gazebros2nix",
+          "nix-ros-overlay",
+          "rosdistro"
+        ],
         "systems": [
           "gepetto",
           "gazebros2nix",
@@ -292,11 +298,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1781362845,
-        "narHash": "sha256-IxhhDOW/aLRltOGHiYTP+Oqr2baRPqtrJYIVvfuw5aE=",
+        "lastModified": 1782566589,
+        "narHash": "sha256-vXVLP31bnnk8KUBUV88Ms2R6P06wdQPZzsXgR6iZ5FI=",
         "owner": "gepetto",
         "repo": "gazebros2nix",
-        "rev": "f45bbdedc06ae9060a14834ee2896199f979d062",
+        "rev": "6e51068e9e9fec8e960f68911127ad64b417bf6b",
         "type": "github"
       },
       "original": {
@@ -399,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781410865,
-        "narHash": "sha256-EC0VzThwka/bPooGIN63c8dEXVaEshw61bm5lNYmI54=",
+        "lastModified": 1783001154,
+        "narHash": "sha256-kPrfWL8YePlBRv0Sz2J4Uwn6C/HlhM3WZG96Y6TEqeU=",
         "owner": "gepetto",
         "repo": "nix",
-        "rev": "ae989cac5c2b3f51131dd54b8fb949ee1b7b2563",
+        "rev": "7a2bf9834c160a05872d0f77eeadc9362cb6f014",
         "type": "github"
       },
       "original": {
@@ -568,11 +574,11 @@
         "gepetto": "gepetto_2"
       },
       "locked": {
-        "lastModified": 1781271796,
-        "narHash": "sha256-ib/hYwNKA5ibWn7ufQ45Gy+VRKNfR552xkr80OsCPhk=",
+        "lastModified": 1782668743,
+        "narHash": "sha256-nHyHqmL/b31tO4/S+lyf9yNL8tYYX2HxNFlvAfb/0k4=",
         "owner": "ahoarau",
         "repo": "jrl-cmakemodules",
-        "rev": "4cfa6b85b49e5b6b2e0f02a9076892afd1050fb1",
+        "rev": "49e8e570d630abf6e978c4ff2b5edab4a0f46d28",
         "type": "github"
       },
       "original": {
@@ -607,11 +613,11 @@
         "rosdistro": "rosdistro"
       },
       "locked": {
-        "lastModified": 1781297240,
-        "narHash": "sha256-OpYxlrSlcqJyknjgIuvv8dtEEbHuuZoe+fJzclrBgmg=",
+        "lastModified": 1781900693,
+        "narHash": "sha256-4KFk+S9ZbMonItYsdPtZjwESsgrCEpXGDa6rosDxLGs=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "9e9b9a2953a195985e1e6c99e353fbb767380a2d",
+        "rev": "fb296510db68c2e760980ab8c6daf6ded9060213",
         "type": "github"
       },
       "original": {
@@ -842,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779676664,
-        "narHash": "sha256-MbXylBTkWqVm8/VYjoULtMoVRgWBN1gSHbeRKsOsPlU=",
+        "lastModified": 1782093830,
+        "narHash": "sha256-6gmEVe69+KlRkZD4PEEV5xAlB9CB0Y9TiuEgQjDrKTQ=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "7bff980f37fc24e09dbc986643719900c139bf12",
+        "rev": "430680a19bc85a3bda55f12e4cc1a1aadcf2e478",
         "type": "github"
       },
       "original": {
@@ -899,11 +905,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780416763,
-        "narHash": "sha256-rRK3IFixgsrK6S3e14Xz9HAZm7+kMAIl3oi5zZlcwYI=",
+        "lastModified": 1782089418,
+        "narHash": "sha256-LRD1SuQWr49fGq3A+8GLXfsLE2xqIpQA440YDZwms3M=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "ad83f1ead0e78e57b188f35cb57298affb06fc5f",
+        "rev": "43f0b40edd0a74c63f66b7b48d969ae6b740d611",
         "type": "github"
       },
       "original": {
@@ -965,11 +971,11 @@
     "rosdistro": {
       "flake": false,
       "locked": {
-        "lastModified": 1780665549,
-        "narHash": "sha256-QzobMKNpcpS4uWETzPxXkt0F66Sji15N+xsK1JcEWDU=",
+        "lastModified": 1781238695,
+        "narHash": "sha256-Sk8KQa9ryFrkdGGZ64sNdqoVqiGmC+IAAi3qzE7zn8s=",
         "owner": "ros",
         "repo": "rosdistro",
-        "rev": "bcec45c05427f0ad6860cb323695995d8cb1e4bd",
+        "rev": "a0e7ccc6f866a081acc0656d9cd03cda7acc6853",
         "type": "github"
       },
       "original": {
@@ -1210,11 +1216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781249037,
-        "narHash": "sha256-Us5r9461lhAZ0cR4oTf7NQuNbp8ETFu0d683AF3mIPE=",
+        "lastModified": 1781810314,
+        "narHash": "sha256-PQfvfKWaBvCysdHFUO5GewwvwIqI/WL6OcrJhDSUdbc=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "ca656fb2cf1c2834e83413c7b2caa2b2d0c2b366",
+        "rev": "14aa44100859a44144878fe079f8089d3fa4dc4e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,12 @@
     inputs:
     let
       flakeModule = inputs.flake-parts.lib.importApply ./module.nix {
-        inherit (inputs) gepetto jrl-cmakemodulesv2 make-shell;
+        inherit (inputs)
+          gepetto
+          flakoboros
+          jrl-cmakemodulesv2
+          make-shell
+          ;
       };
       inputTriggers = {
         buildPrivate = inputs.private-trigger.value or false;

--- a/module.nix
+++ b/module.nix
@@ -2,6 +2,7 @@
 # as opposed to the flake where this is imported.
 {
   gepetto,
+  flakoboros,
   jrl-cmakemodulesv2,
   make-shell,
   ...
@@ -11,13 +12,63 @@
 # where this module was imported.
 {
   lib,
-  stdenv,
   config,
   ...
 }:
+let
+  cfg = config.mc-rtc-nix;
+  flakoboros-cfg = config.flakoboros;
+  rosDistro =
+    let
+      distro = flakoboros-cfg.rosShellDistro;
+    in
+    builtins.trace "rosDistro evaluated to: ${distro}" distro;
+
+  qtVersion =
+    let
+      version = flakoboros.lib.ros2qt rosDistro;
+    in
+    builtins.trace "qtVersion evaluated to: ${version}" version;
+
+  # Define overlays as pure functions to avoid accessing `pkgs` at the root config level
+  mcRtcPkgsOverlay =
+    final: prev:
+    let
+      qt = if (qtVersion == "5") then final.qt5 else final.qt6;
+    in
+    (import ./overlay.nix {
+      inherit lib;
+      stdenv = prev.stdenv;
+      with-ros = cfg.with-ros;
+      with-python = cfg.with-python;
+      inherit qt;
+    })
+      final
+      prev;
+
+  mcRtcPrivateOverlay =
+    final: prev:
+    let
+      qt = if (qtVersion == "5") then final.qt5 else final.qt6;
+    in
+    (import ./overlay-private.nix {
+      with-ros = cfg.with-ros;
+      with-python = cfg.with-python;
+      inherit qt;
+    })
+      final
+      prev;
+
+  jrlCmakeModulesOverlay = _final: prev: {
+    jrl-cmakemodulesv2 = jrl-cmakemodulesv2.packages.${prev.system}.default;
+  };
+
+  mcRtcCcacheOverlay = import ./overlay-ccache.nix { };
+
+  superbuildFlakeModule = ./modules/superbuild/superbuild.nix;
+in
 {
   options.mc-rtc-nix = {
-    # Root level option
     with-ros = lib.mkOption {
       type = lib.types.bool;
       default = true;
@@ -40,7 +91,11 @@
       devShells = lib.mkEnableOption "adds gepetto devShells";
     };
 
-    packages = lib.mkEnableOption "adds mc-rtc-nix packages";
+    packages = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "adds mc-rtc-nix packages";
+    };
   };
 
   options.mc-rtc-superbuild = lib.mkOption {
@@ -58,216 +113,182 @@
     make-shell.flakeModules.default
   ];
 
-  config =
-    let
-      cfg = config.mc-rtc-nix;
+  config = {
+    flake.overlays = {
+      mc-rtc-pkgs = mcRtcPkgsOverlay;
+      make-shell = make-shell.overlays.default;
+    }
+    // lib.optionalAttrs cfg.overlays.private {
+      mc-rtc-private = mcRtcPrivateOverlay;
+    }
+    // {
+      jrl-cmakemodulesv2 = jrlCmakeModulesOverlay;
+    }
+    // lib.optionalAttrs cfg.overlays.ccache {
+      mc-rtc-ccache = mcRtcCcacheOverlay;
+    };
 
-      rawOverlays = [
-        {
-          name = "mc-rtc-pkgs";
-          value = import ./overlay.nix {
-            inherit lib;
-            inherit stdenv;
-            with-ros = cfg.with-ros;
-            with-python = cfg.with-python;
-          };
-        }
-        {
-          name = "make-shell";
-          value = make-shell.overlays.default;
-        }
+    flake.flakeModules.superbuild = superbuildFlakeModule;
+
+    flakoboros = {
+      rosShellDistro = "kilted";
+      extraPackages = [ "ninja" ];
+      overlays = [
+        mcRtcPkgsOverlay
+        make-shell.overlays.default
       ]
-      ++ (lib.optional cfg.overlays.private {
-        name = "mc-rtc-private";
-        value = import ./overlay-private.nix {
-          with-ros = cfg.with-ros;
-          with-python = cfg.with-python;
-        };
-      })
-      ++ [
-        {
-          name = "jrl-cmakemodulesv2";
-          value = (
-            _final: prev: { jrl-cmakemodulesv2 = jrl-cmakemodulesv2.packages.${prev.system}.default; }
-          );
-        }
-      ]
-      ++ (lib.optional cfg.overlays.ccache {
-        name = "mc-rtc-ccache";
-        value = import ./overlay-ccache.nix { };
-      });
+      ++ lib.optional cfg.overlays.private mcRtcPrivateOverlay
+      ++ [ jrlCmakeModulesOverlay ]
+      ++ lib.optional cfg.overlays.ccache mcRtcCcacheOverlay;
 
-      flakeOverlays = builtins.listToAttrs (
-        map (o: {
-          inherit (o) name;
-          value = o.value;
-        }) rawOverlays
-      );
-
-      overlaysList = map (o: o.value) rawOverlays;
-      overlaysListTraced = builtins.trace "mc-rtc-nix: adding additional overlays: ${toString (map (o: o.name) rawOverlays)}" overlaysList;
-
-      superbuildFlakeModule = ./modules/superbuild/superbuild.nix;
-
-    in
-    {
-      flake.overlays = flakeOverlays;
-      flake.flakeModules.superbuild = superbuildFlakeModule;
-
-      flakoboros = {
-        extraPackages = [ "ninja" ];
-        overlays = overlaysListTraced;
-        nixpkgsConfig = {
-          permittedInsecurePackages = [ "openssl-1.1.1w" ];
-        };
+      nixpkgsConfig = {
+        permittedInsecurePackages = [ "openssl-1.1.1w" ];
       };
+    };
 
-      perSystem = (
-        { pkgs, inputs', ... }:
-        let
-          superbuildCfg =
-            (lib.evalModules {
-              modules = [
-                { options = import ./modules/superbuild/options.nix { inherit lib; }; }
-                config.mc-rtc-superbuild
+    perSystem = (
+      { pkgs, inputs', ... }:
+      let
+        superbuildCfg =
+          (lib.evalModules {
+            modules = [
+              { options = import ./modules/superbuild/options.nix { inherit lib; }; }
+              config.mc-rtc-superbuild
+            ];
+            specialArgs = { inherit pkgs; };
+          }).config;
+
+        builtInConfigurations = {
+          minimal = {
+            runtime = { };
+          };
+
+          default = {
+            extends = [ "minimal" ];
+            runtime = {
+              observers = [ pkgs.mc-state-observation ];
+              apps = [
+                pkgs.mc-rtc-magnum
+              ]
+              ++ lib.optionals (cfg.with-ros || superbuildCfg.withRos) [ pkgs.mc-rtc-ticker ];
+            };
+          };
+
+          default-all-robots = {
+            extends = [ "default" ];
+            runtime = with pkgs; {
+              robots = [
+                mc-g1
+                mc-h1
+                mc-panda
+                mc-panda-lirmm
+                mc-robogami
+              ]
+              ++ lib.optionals (cfg.with-ros || superbuildCfg.withRos) [
+                mc-ur5e
+              ]
+              ++ lib.optionals cfg.overlays.private [
+                mc-hrp2
+                mc-hrp4
+                mc-hrp5-p
               ];
-              specialArgs = { inherit pkgs; };
-            }).config;
-
-          builtInConfigurations = {
-            minimal = {
-              runtime = {
-              };
+              controllers = [ robogami-controller ];
             };
+          };
 
-            default = {
-              extends = [ "minimal" ];
-              runtime = {
-                observers = [ pkgs.mc-state-observation ];
-                apps = [
-                  pkgs.mc-rtc-magnum
-                ]
-                ++ lib.optionals cfg.with-ros [ pkgs.mc-rtc-ticker ];
-              };
+          full = {
+            extends = [ "default-all-robots" ];
+            runtime = {
+              plugins = [
+                pkgs.mc-robot-model-update
+              ]
+              ++ lib.optionals (!pkgs.stdenv.hostPlatform.isDarwin) [
+                pkgs.mc-force-shoe-plugin
+              ];
+              apps = lib.optionals (cfg.overlays.private && !pkgs.stdenv.hostPlatform.isDarwin) [
+                pkgs.mc-mujoco-full
+              ];
             };
+          };
+        };
 
-            default-all-robots = {
-              extends = [ "default" ];
-              runtime = with pkgs; {
-                robots = [
-                  mc-g1
-                  mc-h1
-                  mc-panda
-                  mc-panda-lirmm
-                  mc-robogami
-                ]
-                ++ lib.optionals cfg.with-ros [
-                  mc-ur5e
-                ]
-                ++ lib.optionals cfg.overlays.private [
-                  mc-hrp2
-                  mc-hrp4
-                  mc-hrp5-p
-                  # FIXME: disable mc-rhps1 as it is too heavy
-                  # pkgs.mc-rhps1
-                ];
-                controllers = [ robogami-controller ];
-              };
-            };
+        configurations = builtInConfigurations // superbuildCfg.configurations;
 
-            full = {
-              extends = [ "default-all-robots" ];
-              runtime = {
-                plugins = [
-                  pkgs.mc-robot-model-update
-                ]
-                ++ lib.optionals (!pkgs.stdenv.hostPlatform.isDarwin) [
-                  pkgs.mc-force-shoe-plugin
-                ];
-                apps = lib.optionals (cfg.overlays.private && !pkgs.stdenv.hostPlatform.isDarwin) [
-                  pkgs.mc-mujoco-full
-                ];
+        mkSuperbuildShell =
+          {
+            mode,
+            shellPname,
+            configuration,
+          }:
+          pkgs.make-shell {
+            imports = [ superbuildFlakeModule ];
+            mc-rtc-superbuild = superbuildCfg // {
+              inherit mode;
+              withRos = cfg.with-ros;
+              configurations = configurations;
+              project = superbuildCfg.project // {
+                pname = shellPname;
+                inherit configuration;
               };
             };
           };
 
-          configurations = builtInConfigurations // superbuildCfg.configurations;
+        shellBaseName = superbuildCfg.project.pname;
 
-          mkSuperbuildShell =
-            {
-              mode,
-              shellPname,
-              configuration,
-            }:
-            pkgs.make-shell {
-              imports = [ superbuildFlakeModule ];
-              mc-rtc-superbuild = superbuildCfg // {
-                inherit mode;
-                withRos = cfg.with-ros;
-                configurations = configurations;
-                project = superbuildCfg.project // {
-                  pname = shellPname;
-                  inherit configuration;
+        mkShellsByPreset =
+          mode: configs:
+          builtins.listToAttrs (
+            map (
+              preset:
+              let
+                name =
+                  (lib.optionalString (shellBaseName != "") "${shellBaseName}-")
+                  + "${preset}"
+                  + lib.optionalString (mode == "devel") "-devel";
+              in
+              {
+                inherit name;
+                value = mkSuperbuildShell {
+                  mode = mode;
+                  shellPname = name;
+                  configuration = preset;
                 };
-              };
-            };
-
-          shellBaseName = superbuildCfg.project.pname;
-
-          mkShellsByPreset =
-            mode: configurations:
-            builtins.listToAttrs (
-              map (
-                preset:
-                let
-                  name =
-                    (lib.optionalString (shellBaseName != "") "${shellBaseName}-")
-                    + "${preset}"
-                    + lib.optionalString (mode == "devel") "-devel";
-                in
-                {
-                  inherit name;
-                  value = mkSuperbuildShell {
-                    mode = mode;
-                    shellPname = name;
-                    configuration = preset;
-                  };
-                }
-              ) (builtins.attrNames configurations)
-            );
-
-          filterConfgurations =
-            defaultShells_: autoShells_:
-            if defaultShells_ then
-              configurations
-            else
-              lib.optionalAttrs autoShells_ superbuildCfg.configurations;
-          releaseShellsByPreset = mkShellsByPreset "release" (
-            filterConfgurations superbuildCfg.shells.defaultShells.release superbuildCfg.shells.autoShells.release
-          );
-          develShellsByPreset = mkShellsByPreset "devel" (
-            filterConfgurations superbuildCfg.shells.defaultShells.devel superbuildCfg.shells.autoShells.devel
+              }
+            ) (builtins.attrNames configs)
           );
 
-          explicitShells = lib.mapAttrs (
-            name: shellCfg:
-            mkSuperbuildShell {
-              mode = shellCfg.mode;
-              shellPname = name;
-              configuration = shellCfg.configuration;
-            }
-          ) superbuildCfg.shells.additionalShells;
+        filterConfgurations =
+          defaultShells_: autoShells_:
+          if defaultShells_ then
+            configurations
+          else
+            lib.optionalAttrs autoShells_ superbuildCfg.configurations;
+        releaseShellsByPreset = mkShellsByPreset "release" (
+          filterConfgurations superbuildCfg.shells.defaultShells.release superbuildCfg.shells.autoShells.release
+        );
+        develShellsByPreset = mkShellsByPreset "devel" (
+          filterConfgurations superbuildCfg.shells.defaultShells.devel superbuildCfg.shells.autoShells.devel
+        );
 
-          hasExplicitShells = superbuildCfg.shells.additionalShells != { };
-          generatedShells =
-            if hasExplicitShells then explicitShells else releaseShellsByPreset // develShellsByPreset;
-        in
-        {
-          # TODO: auto-generate
-          packages = lib.mkMerge [
-            (lib.mkIf cfg.gepetto.packages inputs'.gepetto.packages)
-            (
-              lib.mkIf cfg.packages {
+        explicitShells = lib.mapAttrs (
+          name: shellCfg:
+          mkSuperbuildShell {
+            mode = shellCfg.mode;
+            shellPname = name;
+            configuration = shellCfg.configuration;
+          }
+        ) superbuildCfg.shells.additionalShells;
+
+        hasExplicitShells = superbuildCfg.shells.additionalShells != { };
+        generatedShells =
+          if hasExplicitShells then explicitShells else releaseShellsByPreset // develShellsByPreset;
+      in
+      {
+        packages = lib.mkMerge [
+          (lib.mkIf cfg.gepetto.packages inputs'.gepetto.packages)
+          (lib.mkIf cfg.packages (
+            lib.mergeAttrsList [
+              {
                 # Main dependencies
                 inherit (pkgs)
                   eigen3-to-python
@@ -325,46 +346,34 @@
 
                 inherit (pkgs) panda-prosthesis mc-force-shoe-plugin sphinx-cmake;
               }
-              // lib.optionalAttrs (cfg.with-ros) {
-                inherit (pkgs)
-                  mc-rtc-ticker
-                  ;
-              }
-              //
-                # TODO: support these on darwin
-                lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isDarwin) {
-                  inherit (pkgs)
-                    mc-udp
-                    ;
-                  inherit (pkgs)
-                    mc-mujoco
-                    mc-mujoco-full
-                    ;
-                }
-              // lib.optionalAttrs cfg.overlays.private {
+              (lib.optionalAttrs (cfg.with-ros || superbuildCfg.withRos) {
+                inherit (pkgs) mc-rtc-ticker;
+              })
+              (lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isDarwin) {
+                inherit (pkgs) mc-udp mc-mujoco mc-mujoco-full;
+              })
+              (lib.optionalAttrs cfg.overlays.private {
                 inherit (pkgs)
                   mc-hrp2
                   mc-hrp4
                   mc-hrp5-p
                   mc-rhps1
                   tasks-lssol
-                  ;
-                inherit (pkgs)
                   politopix
                   mc-dynamic-polytopes
                   dcm-vrptask
                   polytopeController
                   ;
-              }
-            )
-          ]; # end mkMerge
+              })
+            ]
+          ))
+        ];
 
-          devShells = lib.mkMerge [
-            (lib.mkIf cfg.gepetto.devShells inputs'.gepetto.devShells)
-            # auto-generated release and devel shells for mc-rtc-superbuild
-            (lib.mkIf superbuildCfg.enable generatedShells)
-          ];
-        }
-      );
-    };
+        devShells = lib.mkMerge [
+          (lib.mkIf cfg.gepetto.devShells inputs'.gepetto.devShells)
+          (lib.mkIf superbuildCfg.enable generatedShells)
+        ];
+      }
+    );
+  };
 }

--- a/module.nix
+++ b/module.nix
@@ -266,102 +266,98 @@
           # TODO: auto-generate
           packages = lib.mkMerge [
             (lib.mkIf cfg.gepetto.packages inputs'.gepetto.packages)
-            (lib.mkIf cfg.packages {
-              # Main dependencies
-              inherit (pkgs)
-                eigen3-to-python
-                spacevecalg
-                rbdyn
-                sch-core
-                sch-core-python
-                tasks
-                tasks-qld
-                tvm
-                eigen-quadprog
-                eigen-qld
-                state-observation
-                mesh-sampling
-                eigen-fmt
-                ;
+            (
+              lib.mkIf cfg.packages {
+                # Main dependencies
+                inherit (pkgs)
+                  eigen3-to-python
+                  spacevecalg
+                  rbdyn
+                  sch-core
+                  sch-core-python
+                  tasks
+                  tasks-qld
+                  tvm
+                  eigen-quadprog
+                  eigen-qld
+                  state-observation
+                  mesh-sampling
+                  eigen-fmt
+                  ;
 
-              # mc-rtc
-              inherit (pkgs) mc-rtc-data mc-rtc;
+                # mc-rtc
+                inherit (pkgs) mc-rtc-data mc-rtc;
 
-              # Main GUIs and applications
-              inherit (pkgs)
-                mc-rtc-magnum
-                mc-franka
-                ;
+                # Main GUIs and applications
+                inherit (pkgs)
+                  mc-rtc-magnum
+                  mc-franka
+                  ;
 
-              # Main robots
-              inherit (pkgs)
-                mc-g1
-                mc-h1
-                mc-ur5e
-                mc-panda
-                mc-panda-lirmm
-                mc-robogami
-                ;
+                # Main robots
+                inherit (pkgs)
+                  mc-g1
+                  mc-h1
+                  mc-ur5e
+                  mc-panda
+                  mc-panda-lirmm
+                  mc-robogami
+                  ;
 
-              # Robot description
-              inherit (pkgs)
-                mc-int-obj-description
-                jvrc-description
-                g1-description
-                h1-description
-                ur5e-description
-                robogami-description
-                ;
+                # Robot description
+                inherit (pkgs)
+                  mc-int-obj-description
+                  jvrc-description
+                  g1-description
+                  h1-description
+                  ur5e-description
+                  robogami-description
+                  ;
 
-              # MuJoCo Robots
-              inherit (pkgs)
-                h1-mj-description
-                jvrc1-mj-description
-                g1-mj-description
-                ur5e-mj-description
-                env-mj-description
-                ;
+                # MuJoCo Robots
+                inherit (pkgs)
+                  h1-mj-description
+                  jvrc1-mj-description
+                  g1-mj-description
+                  ur5e-mj-description
+                  env-mj-description
+                  ;
 
-              # Controllers
-              inherit (pkgs)
-                robogami-controller
-                ;
-              # lipm-walking-controller # FIXME: per-robot configuration
-
-              inherit (pkgs) panda-prosthesis mc-force-shoe-plugin sphinx-cmake;
-            })
-            (lib.mkIf cfg.with-ros {
-              inherit (pkgs)
-                mc-rtc-ticker
-                ;
-            })
-            # TODO: support these on darwin
-            (lib.mkIf (!pkgs.stdenv.hostPlatform.isDarwin) {
-              inherit (pkgs)
-                mc-udp
-                ;
-              inherit (pkgs)
-                mc-mujoco
-                mc-mujoco-full
-                ;
-            })
-            (lib.mkIf (cfg.packages && cfg.overlays.private) {
-              inherit (pkgs)
-                mc-hrp2
-                mc-hrp4
-                mc-hrp5-p
-                mc-rhps1
-                eigen-lssol
-                tasks-lssol
-                ;
-              inherit (pkgs)
-                politopix
-                mc-dynamic-polytopes
-                dcm-vrptask
-                polytopeController
-                ;
-            })
-          ];
+                inherit (pkgs) panda-prosthesis mc-force-shoe-plugin sphinx-cmake;
+              }
+              // lib.optionalAttrs (cfg.with-ros) {
+                inherit (pkgs)
+                  mc-rtc-ticker
+                  ;
+              }
+              //
+                # TODO: support these on darwin
+                lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isDarwin) {
+                  inherit (pkgs)
+                    mc-udp
+                    ;
+                  inherit (pkgs)
+                    mc-mujoco
+                    mc-mujoco-full
+                    ;
+                }
+              // lib.optionalAttrs cfg.overlays.private {
+                inherit (pkgs)
+                  mc-hrp2
+                  mc-hrp4
+                  mc-hrp5-p
+                  mc-rhps1
+                  tasks-lssol
+                  ;
+                inherit (pkgs)
+                  politopix
+                  mc-dynamic-polytopes
+                  dcm-vrptask
+                  polytopeController
+                  ;
+              }
+            )
+          ]; # end mkMerge
 
           devShells = lib.mkMerge [
             (lib.mkIf cfg.gepetto.devShells inputs'.gepetto.devShells)

--- a/module.nix
+++ b/module.nix
@@ -131,6 +131,8 @@ in
     flake.flakeModules.superbuild = superbuildFlakeModule;
 
     flakoboros = {
+      # FIXME: Flakoboros pulls in qtwayland that does not exist on macos
+      enableQt = false;
       rosShellDistro = "kilted";
       extraPackages = [ "ninja" ];
       overlays = [

--- a/overlay.nix
+++ b/overlay.nix
@@ -9,6 +9,7 @@
   lib,
   with-ros ? false,
   with-python ? true,
+  qt, # qt5 or qt6
   ...
 }:
 (
@@ -123,11 +124,14 @@
     mc-rtc = callWithRos ./pkgs/mc-rtc/mc-rtc.nix {
       with-python-bindings = with-python;
       with-python-tools = true;
+      inherit qt;
     };
     mc-rtc-python-utils = prev.callPackage ./pkgs/mc-rtc/mc-rtc-python-utils.nix { };
     #mc-rtc = callWithRos ./pkgs/mc-rtc/mc-rtc.nix {};
     # mc-rtc-rviz-panel = prev.libsForQt5.callPackage ./pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix { inherit useLocal; inherit localWorkspace; };
-    mc-rtc-rviz-panel = prev.libsForQt5.callPackage ./pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix { };
+    mc-rtc-rviz-panel = prev.libsForQt5.callPackage ./pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix {
+      inherit qt;
+    };
     # mc-rtc-ticker = prev.callPackage ./pkgs/mc-rtc/ros/mc-rtc-ticker.nix {};
     mc-rtc-ticker = prev.callPackage ./pkgs/mc-rtc/ros/mc-rtc-ticker.nix { };
     # mc-rtc = prev.callPackage ./pkgs/mc-rtc/mc-rtc.nix { with-ros = true; };

--- a/pkgs/mc-rtc/mc-rtc.nix
+++ b/pkgs/mc-rtc/mc-rtc.nix
@@ -26,6 +26,7 @@
   mesh-sampling,
   python3Packages,
   qt5,
+  makeWrapper,
   doxygen,
   bundler, # Ruby for bundle dependencies
   with-ros ? false,
@@ -61,10 +62,12 @@ in
 
   buildInputs = [
     jrl-cmakemodules
+    qt5.qtbase
   ];
   nativeBuildInputs = [
     cmake
     qt5.wrapQtAppsHook
+    makeWrapper
     # for documentation
     doxygen
     bundler
@@ -142,6 +145,13 @@ in
       echo "Shrinking RPATH for $binary"
       patchelf --shrink-rpath --allowed-rpath-prefixes "$NIX_STORE" "$binary"
     done
+  '';
+
+  # Prevent Qt5 variables from being globally leaked or attached to other binaries
+  dontWrapQtApps = true;
+  postFixup = lib.optionalString with-python-tools ''
+    echo "Wrapping mc_log_ui with Qt5 environment variables..."
+    wrapProgram "$out/bin/mc_log_ui" "''${qtWrapperArgs[@]}"
   '';
 
   meta = with lib; {

--- a/pkgs/mc-rtc/mc-rtc.nix
+++ b/pkgs/mc-rtc/mc-rtc.nix
@@ -25,8 +25,7 @@
   boost,
   mesh-sampling,
   python3Packages,
-  qt5,
-  makeWrapper,
+  qt,
   doxygen,
   bundler, # Ruby for bundle dependencies
   with-ros ? false,
@@ -46,6 +45,14 @@ let
     inherit fetchFromGitHub;
   };
   use-python-bindings = with-python-bindings && !stdenv.hostPlatform.isDarwin;
+  use-python-tools =
+    with-python-tools
+    && (
+      if lib.hasInfix "qtbase-5" qt.qtbase.name then
+        true
+      else
+        builtins.trace "warning: mc-rtc is requesting with-python-tools but it is not compatible with qt6, will build without it." false
+    );
 in
 
 (if with-ros then buildRosPackage else stdenv.mkDerivation) {
@@ -62,17 +69,16 @@ in
 
   buildInputs = [
     jrl-cmakemodules
-    qt5.qtbase
+    qt.qtbase
   ];
   nativeBuildInputs = [
     cmake
-    qt5.wrapQtAppsHook
-    makeWrapper
     # for documentation
     doxygen
     bundler
   ]
-  ++ lib.optionals (use-python-bindings || with-python-tools) [ python3Packages.python ]
+  ++ lib.optional use-python-tools qt.wrapQtAppsHook
+  ++ lib.optional (use-python-bindings || use-python-tools) python3Packages.python
   ++ lib.optionals use-python-bindings [
     python3Packages.distutils
     python3Packages.pytest
@@ -103,7 +109,7 @@ in
       python3Packages.tasks
     ]
   # for python utils (mc_rtc_new_fsm_controller, mc_log_ui, etc)
-  ++ lib.optionals with-python-tools [
+  ++ lib.optionals use-python-tools [
     python3Packages.gitpython
     python3Packages.pyqt5
     python3Packages.matplotlib
@@ -123,7 +129,7 @@ in
 
   cmakeFlags = [
     (lib.cmakeBool "PYTHON_BINDING" use-python-bindings)
-    (lib.cmakeBool "BUILD_MC_RTC_PYTHON_UTILS" with-python-tools) # does not need bindings
+    (lib.cmakeBool "BUILD_MC_RTC_PYTHON_UTILS" use-python-tools) # does not need bindings
     "-DBUILD_TESTING=OFF" # FIXME
     "-DINSTALL_DOCUMENTATION=ON" # Use a different output
   ];
@@ -131,13 +137,10 @@ in
   doCheck = true;
 
   passthru = {
-    inherit with-ros with-python-tools;
+    inherit with-ros;
+    with-python-tools = use-python-tools;
     with-python-bindings = use-python-bindings;
   };
-
-  postInstall = lib.optionalString with-python-tools ''
-    wrapQtApp $out/bin/mc_log_ui
-  '';
 
   # XXX: Without this fixupPhase fails due to RPATHS references to /build/
   preFixup = lib.optionalString use-python-bindings ''
@@ -145,13 +148,6 @@ in
       echo "Shrinking RPATH for $binary"
       patchelf --shrink-rpath --allowed-rpath-prefixes "$NIX_STORE" "$binary"
     done
-  '';
-
-  # Prevent Qt5 variables from being globally leaked or attached to other binaries
-  dontWrapQtApps = true;
-  postFixup = lib.optionalString with-python-tools ''
-    echo "Wrapping mc_log_ui with Qt5 environment variables..."
-    wrapProgram "$out/bin/mc_log_ui" "''${qtWrapperArgs[@]}"
   '';
 
   meta = with lib; {

--- a/pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix
+++ b/pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix
@@ -19,12 +19,12 @@
 
 let
   pname = "mc-rtc-rviz-panel";
-  version = "1.6.1";
+  version = "1.7.0";
   fetched = fetchFromGitHub {
     owner = "jrl-umi3218";
     repo = "mc_rtc_ros";
-    rev = "d769df946c38f8a5befc2fe790fdba9ac739d566"; # TODO: release mc_rtc_ros
-    sha256 = "sha256-Gmxv/nYKGcK9G1r0i08kLzTc2Dj8qCAQA/S0bic1LKA=";
+    rev = "f08a371289c49e677cd5107c581569811b03117f";
+    hash = "sha256-/hWW4ETOUEGo8wFOBA97dt0ZmOB0AI7mfs35/cfIDJE=";
   };
   # fetchFromGitHub {
   #   owner = "arntanguy";

--- a/pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix
+++ b/pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix
@@ -4,7 +4,7 @@
   ament-cmake,
   fetchFromGitHub,
   mc-rtc,
-  qt5,
+  qt, # either qt5 or qt6
   qwt,
   libGL,
   libGLU,
@@ -48,7 +48,7 @@ buildRosPackage {
     rviz2
     visualization-msgs
     tf2-ros
-    qt5.qtbase
+    qt.qtbase
     qwt
     libGL
     libGLU


### PR DESCRIPTION
Should fix the issue

```
ros-env> structuredAttrs is enabled
ros-env> Error: detected mismatched Qt dependencies:
ros-env>     /nix/store/sg43zvnkh9hfscqvlqir3pcdxl0kd00l-qtbase-5.15.18-dev
ros-env>     /nix/store/1q8sx67miwfn3ws5k7mkmkcjbym4akkp-qtbase-6.11.0
error: Cannot build '/nix/store/sr6bmpqaaym28nc5dh0mg8wwlzy7r6l7-ros-env.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/7wflgdidav6kk2dmmxxxjv5ldjazxypf-ros-env
       Last 4 log lines:
       > structuredAttrs is enabled
       > Error: detected mismatched Qt dependencies:
       >     /nix/store/sg43zvnkh9hfscqvlqir3pcdxl0kd00l-qtbase-5.15.18-dev
       >     /nix/store/1q8sx67miwfn3ws5k7mkmkcjbym4akkp-qtbase-6.11.0
       For full logs, run:
         nix log /nix/store/sr6bmpqaaym28nc5dh0mg8wwlzy7r6l7-ros-env.drv
```

The root cause is

> Only python utils need to be wrapped by qt5 wrapping hooks, not the
whole library! This leaks Qt5 libraries, and prevents downstream
derivations (e.g mc-rtc-rviz-panel) from building against qt6!
