### PR TITLE
feat!: fix ccache overlay and enable by default, add ismpc

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     # This is used by CI to activate the private overlay while remaining in pure evaluation mode
     # Use as nix build . --override-input private-trigger github:boolean-option/true
     private-trigger.url = "github:boolean-option/false";
-    ccache-trigger.url = "github:boolean-option/false";
+    ccache-trigger.url = "github:boolean-option/true";
     with-ros-trigger.url = "github:boolean-option/true";
     with-python-trigger.url = "github:boolean-option/true";
   };

--- a/module.nix
+++ b/module.nix
@@ -136,12 +136,14 @@ in
       rosShellDistro = "kilted";
       extraPackages = [ "ninja" ];
       overlays = [
-        mcRtcPkgsOverlay
-        make-shell.overlays.default
+        (builtins.trace "using overlay mc-rtc-pkgs (public)" mcRtcPkgsOverlay)
+        (builtins.trace "using overlay make-shell" make-shell.overlays.default)
       ]
-      ++ lib.optional cfg.overlays.private mcRtcPrivateOverlay
+      ++ lib.optional cfg.overlays.private (
+        builtins.trace "using overlay mc-rtc-private" mcRtcPrivateOverlay
+      )
       ++ [ jrlCmakeModulesOverlay ]
-      ++ lib.optional cfg.overlays.ccache mcRtcCcacheOverlay;
+      ++ lib.optional cfg.overlays.ccache (builtins.trace "using overlay ccache" mcRtcCcacheOverlay);
 
       nixpkgsConfig = {
         permittedInsecurePackages = [ "openssl-1.1.1w" ];
@@ -402,7 +404,16 @@ in
                   ;
 
                 # Controllers
-                inherit (pkgs) panda-prosthesis robogami-controller lipm-walking-controller;
+                inherit (pkgs)
+                  panda-prosthesis
+                  robogami-controller
+                  lipm-walking-controller
+                  # ismpc
+                  footsteps-planner-plugin
+                  pendulum-feasibility-solver
+                  ismpc-walking-controller
+                  mc-joystick-plugin
+                  ;
 
                 # Plugins
                 inherit (pkgs) mc-force-shoe-plugin;

--- a/overlay-ccache.nix
+++ b/overlay-ccache.nix
@@ -20,6 +20,12 @@ let
   skipCcahePackages = [
     "mc-rtc-msgs"
     "magnum-with-plugins"
+    "mc-rtc-ticker"
+    "mc-rtc-rviz-panel"
+    "mc-mujoco-robots-public"
+    "mc-mujoco-robots-private"
+    "mc-mujoco-robots"
+    "ur-description"
   ];
   allPackages = [
     "nanomsg"

--- a/overlay-ccache.nix
+++ b/overlay-ccache.nix
@@ -27,7 +27,7 @@ let
     "mc-mujoco-robots"
     "ur-description"
   ];
-  allPackages = [
+  allPublicPackages = [
     "nanomsg"
     "eigen3-to-python"
     "spacevecalg"
@@ -109,6 +109,32 @@ let
     "sphinx-cmake"
     "mc-robot-tools"
   ];
+  allPivatePackages = [
+    "eigen-lssol"
+    "hrp2-description"
+    "hrp4-description"
+    "hrp5-p-description"
+    "rhps1-description"
+    "miroki-description"
+    "mc-hrp2"
+    "mc-hrp4"
+    "mc-hrp5-p"
+    "mc-rhps1"
+    "mc-miroki"
+    "rhps1-mj-description"
+    "hrp4-mj-description"
+    "hrp5p-mj-description"
+    "tasks-lssol"
+    "tasks"
+    "mc-rtc"
+    "politopix"
+    "mc-dynamic-polytopes"
+    "dcm-vrptask"
+    "polytopeController"
+    "mc-mujoco-robots-private"
+    "mc-mujoco-full"
+  ];
+  allPackages = allPublicPackages ++ allPivatePackages;
   ccachePackages = builtins.filter (name: !(builtins.elem name skipCcahePackages)) allPackages;
 in
 {

--- a/overlay-ccache.nix
+++ b/overlay-ccache.nix
@@ -8,9 +8,102 @@ let
     listToAttrs (
       map (name: {
         inherit name;
-        value = (getAttr name prev).override { stdenv = prev.ccacheStdenv; };
+        value =
+          builtins.trace "overriding stdenv with ccacheStdenv for package ${name}"
+            (getAttr name prev).override
+            { stdenv = prev.ccacheStdenv; };
       }) packages
     );
+  # usually this mean they don't have stdenv as an agument
+  # if they are built with buildRosPackages they will use ccache anyways
+  # XXX: Can we automate this?
+  skipCcahePackages = [
+    "mc-rtc-msgs"
+    "magnum-with-plugins"
+  ];
+  allPackages = [
+    "nanomsg"
+    "eigen3-to-python"
+    "spacevecalg"
+    "rbdyn"
+    "eigen-qld"
+    "eigen-quadprog"
+    "sch-core"
+    "sch-core-python"
+    "sch-visualization"
+    "tasks-qld"
+    "tasks"
+    "mc-rtc-data"
+    "state-observation"
+    "mc-rbdyn-urdf"
+    "tvm"
+    "copra"
+    "omniorb"
+    "openrtm-aist"
+    "openrtm-aist-python"
+    "mc-state-observation"
+    "lipm-walking-controller"
+    "pendulum-feasibility-solver"
+    "footsteps-planner-plugin"
+    "mc-joystick-plugin"
+    "ismpc-walking-controller"
+    "robogami-controller"
+    "mc-udp"
+    "franka-description"
+    "g1-description"
+    "h1-description"
+    "ur-description"
+    "ur5e-description"
+    "human-description"
+    "jvrc-description"
+    "mc-env-description"
+    "mc-int-obj-description"
+    "robogami-description"
+    "pepper-description"
+    "mc-g1"
+    "mc-h1"
+    "mc-ur5e"
+    "mc-human"
+    "mc-panda"
+    "mc-panda-lirmm"
+    "mc-robogami"
+    "mc-pepper"
+    "libfranka_0_9_2"
+    "mc-franka"
+    "mesh-sampling"
+    "mc-rtc"
+    "mc-rtc-ros-compat"
+    "mc-rtc-python-utils"
+    "mc-rtc-rviz-panel"
+    "mc-rtc-ticker"
+    "gram-savitzky-golay"
+    "mujoco"
+    "jvrc1-mj-description"
+    "g1-mj-description"
+    "h1-mj-description"
+    "ur5e-mj-description"
+    "human-mj-description"
+    "env-mj-description"
+    "mc-mujoco"
+    "mc-mujoco-robots"
+    "mc-mujoco-robots-public"
+    "mc-mujoco-full"
+    "panda-prosthesis"
+    "mc-force-shoe-plugin"
+    "mc-robot-model-update"
+    "eigen-fmt"
+    "imguizmo"
+    "corrade"
+    "magnum"
+    "magnum-integration"
+    "magnum-plugins"
+    "magnum-with-plugins"
+    "mc-rtc-imgui"
+    "mc-rtc-magnum"
+    "sphinx-cmake"
+    "mc-robot-tools"
+  ];
+  ccachePackages = builtins.filter (name: !(builtins.elem name skipCcahePackages)) allPackages;
 in
 {
   ccacheWrapper = prev.ccacheWrapper.override {
@@ -37,42 +130,15 @@ in
         echo "  echo 'extra-sandbox-paths = /var/cache/ccache' >> ~/.config/nix/nix.conf"
         echo "  sudo systemctl restart nix-daemon.service"
         echo "====="
-        exit 1
       fi
       if [ ! -w "$CCACHE_DIR" ]; then
         echo "====="
         echo "Directory '$CCACHE_DIR' is not accessible for user $(whoami)"
         echo "Please verify its access permissions"
         echo "====="
-        exit 1
       fi
     '';
   };
 }
-// withCCache [
-  "spacevecalg"
-  "rbdyn"
-  "sch-core"
-  "eigen-qld"
-  "eigen-quadprog"
-  "tasks"
-  "tvm"
-  "mc-rtc-magnum"
-  "mc-rtc-magnum-standalone"
-  "mc-panda"
-  "mc-panda-lirmm"
-  "libpoco"
-  "libfranka"
-  "mc-franka"
-  "panda-prosthesis"
-
-  "mc-force-shoe-plugin"
-
-  "magnum"
-  "magnum-integration"
-  "magnum-plugins"
-  "mc_rtc-imgui"
-
-  # "mc-rtc-rviz-panel" # how to make it work for buildRosPackage?
-  "mc-rtc"
-]
+// withCCache [ "buildRosPackage" ]
+// withCCache ccachePackages

--- a/overlay-private.nix
+++ b/overlay-private.nix
@@ -6,27 +6,31 @@
 (
   final: prev:
   let
-    callWithRos = pkg: args: prev.callPackage pkg (args // { inherit with-ros; });
+    callWithRos = pkg: args: final.callPackage pkg (args // { inherit with-ros; });
   in
   {
-    eigen-lssol = prev.callPackage ./pkgs/eigen-lssol/default.nix { };
+    eigen-lssol = final.callPackage ./pkgs/eigen-lssol/default.nix { };
     hrp2-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/hrp2-description.nix { };
     hrp4-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/hrp4-description.nix { };
     hrp5-p-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/hrp5-p-description.nix { };
     rhps1-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/rhps1-description.nix { };
     miroki-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/miroki-description.nix { };
-    mc-hrp2 = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-hrp2.nix { };
-    mc-hrp4 = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-hrp4.nix { };
-    mc-hrp5-p = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-hrp5-p.nix { };
-    mc-rhps1 = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-rhps1.nix { };
-    mc-miroki = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-miroki.nix { };
+    mc-hrp2 = final.callPackage ./pkgs/mc-rtc/robots/modules/mc-hrp2.nix { };
+    mc-hrp4 = final.callPackage ./pkgs/mc-rtc/robots/modules/mc-hrp4.nix { };
+    mc-hrp5-p = final.callPackage ./pkgs/mc-rtc/robots/modules/mc-hrp5-p.nix { };
+    mc-rhps1 = final.callPackage ./pkgs/mc-rtc/robots/modules/mc-rhps1.nix { };
+    mc-miroki = final.callPackage ./pkgs/mc-rtc/robots/modules/mc-miroki.nix { };
 
-    rhps1-mj-description = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/rhps1-mj-description.nix { };
-    hrp4-mj-description = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/hrp4-mj-description.nix { };
-    hrp5p-mj-description = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/hrp5p-mj-description.nix { };
+    rhps1-mj-description =
+      final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/rhps1-mj-description.nix
+        { };
+    hrp4-mj-description = final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/hrp4-mj-description.nix { };
+    hrp5p-mj-description =
+      final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/hrp5p-mj-description.nix
+        { };
     # TODO: hrp2-mj-description does not exist
 
-    tasks-lssol = prev.callPackage ./pkgs/tasks {
+    tasks-lssol = final.callPackage ./pkgs/tasks {
       with-lssol = true;
       inherit with-python;
     };
@@ -41,30 +45,30 @@
     };
     # TODO ask I2S Bordeaux to make it public
     # Hugo's dependencies
-    politopix = prev.callPackage ./pkgs/3rd-party/politopix.nix { };
+    politopix = final.callPackage ./pkgs/3rd-party/politopix.nix { };
 
     # FIXME: { won't build as-is here as it requires a branch of mc-rtc for now
     # See https://github.com/Hugo-L3174/polytopeController's flake.nix
     # As they are currently not in the flake.nix's package set, this is probably ok to
     # have non-building versions in the overlay (?)
     mc-dynamic-polytopes =
-      prev.callPackage ./pkgs/mc-rtc/controllers/polytopeController/mc-dynamic-polytopes.nix
+      final.callPackage ./pkgs/mc-rtc/controllers/polytopeController/mc-dynamic-polytopes.nix
         {
           jrl-cmakemodules = final.jrl-cmakemodulesv2;
           # mc-rtc = final.mc-rtc-hugo;
         };
-    dcm-vrptask = prev.callPackage ./pkgs/mc-rtc/controllers/polytopeController/dcm-vrptask.nix {
+    dcm-vrptask = final.callPackage ./pkgs/mc-rtc/controllers/polytopeController/dcm-vrptask.nix {
       # mc-rtc = final.mc-rtc-hugo;
       jrl-cmakemodules = final.jrl-cmakemodulesv2;
     };
-    polytopeController = prev.callPackage ./pkgs/mc-rtc/controllers/polytopeController/default.nix {
+    polytopeController = final.callPackage ./pkgs/mc-rtc/controllers/polytopeController/default.nix {
       # mc-rtc = final.mc-rtc-hugo;
     };
     # End of Hugo's dependencies
     # } end of FIXME
 
     # mc-mujoco with private robots
-    mc-mujoco-robots-private = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix {
+    mc-mujoco-robots-private = final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix {
       robots = [
         final.rhps1-mj-description
         final.hrp4-mj-description
@@ -73,9 +77,9 @@
       ];
     };
 
-    mc-mujoco-full = prev.callPackage ./pkgs/mc-rtc/mc-mujoco {
+    mc-mujoco-full = final.callPackage ./pkgs/mc-rtc/mc-mujoco {
       jrl-cmakemodules = final.jrl-cmakemodulesv2;
-      mc-mujoco-robots = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix {
+      mc-mujoco-robots = final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix {
         robots = final.mc-mujoco-robots-public.robots ++ final.mc-mujoco-robots-private.robots;
       };
     };

--- a/overlay.nix
+++ b/overlay.nix
@@ -15,7 +15,7 @@
 (
   final: prev:
   let
-    callWithRos = pkg: args: prev.callPackage pkg (args // { inherit with-ros; });
+    callWithRos = pkg: args: final.callPackage pkg (args // { inherit with-ros; });
   in
   {
     inherit (prev.rosPackages.jazzy)
@@ -48,50 +48,62 @@
       '';
     });
 
-    eigen3-to-python = prev.callPackage ./pkgs/eigen3-to-python { };
-    spacevecalg = prev.callPackage ./pkgs/spacevecalg { inherit with-python; };
-    rbdyn = prev.callPackage ./pkgs/rbdyn { inherit with-python; };
-    eigen-qld = prev.callPackage ./pkgs/eigen-qld { };
-    eigen-quadprog = prev.callPackage ./pkgs/eigen-quadprog { };
-    sch-core = prev.callPackage ./pkgs/sch-core { };
-    sch-core-python = prev.callPackage ./pkgs/sch-core-python { };
-    #sch-visualization = prev.callPackage ./pkgs/sch-visualization {};
-    sch-visualization = prev.callPackage ./pkgs/sch-visualization { };
-    tasks-qld = prev.callPackage ./pkgs/tasks { inherit with-python; };
+    eigen3-to-python = final.callPackage ./pkgs/eigen3-to-python { };
+    spacevecalg = final.callPackage ./pkgs/spacevecalg { inherit with-python; };
+    rbdyn = final.callPackage ./pkgs/rbdyn { inherit with-python; };
+    eigen-qld = final.callPackage ./pkgs/eigen-qld { };
+    eigen-quadprog = final.callPackage ./pkgs/eigen-quadprog { };
+    sch-core = final.callPackage ./pkgs/sch-core { };
+    sch-core-python = final.callPackage ./pkgs/sch-core-python { };
+    #sch-visualization = final.callPackage ./pkgs/sch-visualization {};
+    sch-visualization = final.callPackage ./pkgs/sch-visualization { };
+    tasks-qld = final.callPackage ./pkgs/tasks { inherit with-python; };
     tasks = final.tasks-qld;
-    # mc-rtc-data = prev.callPackage ./pkgs/mc-rtc-data { with-ros = false; };
+    # mc-rtc-data = final.callPackage ./pkgs/mc-rtc-data { with-ros = false; };
     mc-rtc-data = callWithRos ./pkgs/mc-rtc-data { };
-    state-observation = prev.callPackage ./pkgs/state-observation { };
-    mc-rbdyn-urdf = prev.callPackage ./pkgs/mc-rbdyn-urdf { };
-    tvm = prev.callPackage ./pkgs/tvm { };
-    copra = prev.callPackage ./pkgs/copra { };
+    state-observation = final.callPackage ./pkgs/state-observation { };
+    mc-rbdyn-urdf = final.callPackage ./pkgs/mc-rbdyn-urdf { };
+    tvm = final.callPackage ./pkgs/tvm { };
+    copra = final.callPackage ./pkgs/copra { };
     omniorb = prev.symlinkJoin {
       name = "omniorb";
       paths = [
         prev.omniorb.out
-        (prev.callPackage ./pkgs/omniorb-python {
+        (final.callPackage ./pkgs/omniorb-python {
           omniorb = prev.omniorb;
           buildPythonPackage = prev.python2Packages.buildPythonPackage;
         }).out
       ];
     };
-    openrtm-aist = prev.callPackage ./pkgs/openrtm-aist { };
-    openrtm-aist-python = prev.callPackage ./pkgs/openrtm-aist-python {
+    openrtm-aist = final.callPackage ./pkgs/openrtm-aist { };
+    openrtm-aist-python = final.callPackage ./pkgs/openrtm-aist-python {
       buildPythonPackage = prev.python2Packages.buildPythonPackage;
     };
-    # mc-state-observation = prev.callPackage ./pkgs/mc-rtc/observers/mc-state-observation;
-    mc-state-observation = prev.callPackage ./pkgs/mc-rtc/observers/mc-state-observation { };
-    lipm-walking-controller = prev.callPackage ./pkgs/mc-rtc/controllers/lipm-walking-controller { };
-    robogami-controller = prev.callPackage ./pkgs/mc-rtc/controllers/robogami-controller { };
-    #mc-rtc-raylib = prev.callPackage ./pkgs/mc-rtc-raylib {};
-    mc-rtc-msgs = prev.callPackage ./pkgs/mc-rtc-msgs { };
-    mc-udp = prev.callPackage ./pkgs/mc-udp { };
+    # mc-state-observation = final.callPackage ./pkgs/mc-rtc/observers/mc-state-observation;
+    mc-state-observation = final.callPackage ./pkgs/mc-rtc/observers/mc-state-observation { };
+    lipm-walking-controller = final.callPackage ./pkgs/mc-rtc/controllers/lipm-walking-controller { };
+    pendulum-feasibility-solver =
+      final.callPackage ./pkgs/mc-rtc/controllers/ismpc-walking/pendulum-feasibility-solver.nix
+        { };
+    footsteps-planner-plugin =
+      final.callPackage ./pkgs/mc-rtc/controllers/ismpc-walking/footsteps-planner-plugin.nix
+        { };
+    mc-joystick-plugin =
+      final.callPackage ./pkgs/mc-rtc/controllers/ismpc-walking/mc-joystick-plugin.nix
+        { };
+    ismpc-walking-controller =
+      final.callPackage ./pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
+        { };
+    robogami-controller = final.callPackage ./pkgs/mc-rtc/controllers/robogami-controller { };
+    #mc-rtc-raylib = final.callPackage ./pkgs/mc-rtc-raylib {};
+    mc-rtc-msgs = final.callPackage ./pkgs/mc-rtc-msgs { };
+    mc-udp = final.callPackage ./pkgs/mc-udp { };
 
     ## Robot description packages
-    franka-description = prev.callPackage ./pkgs/mc-rtc/robots/mc-panda/franka-description.nix { };
+    franka-description = final.callPackage ./pkgs/mc-rtc/robots/mc-panda/franka-description.nix { };
     g1-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/g1-description.nix { };
     h1-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/h1-description.nix { };
-    ur-description = prev.callPackage ./pkgs/mc-rtc/robots/descriptions/ur-description.nix { };
+    ur-description = final.callPackage ./pkgs/mc-rtc/robots/descriptions/ur-description.nix { };
     ur5e-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/ur5e-description.nix { };
     human-description = callWithRos ./pkgs/mc-rtc/robots/descriptions/human-description.nix { };
     jvrc-description = callWithRos ./pkgs/mc-rtc-data/jvrc-description.nix { };
@@ -101,22 +113,23 @@
     pepper-description = callWithRos ./pkgs/mc-rtc/robots/mc-pepper/pepper-description.nix { };
 
     # Robot modules
-    mc-g1 = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-g1.nix { };
-    mc-h1 = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-h1.nix { };
-    mc-ur5e = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-ur5e.nix { };
-    mc-human = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-human.nix { };
-    mc-panda = prev.callPackage ./pkgs/mc-rtc/robots/mc-panda { };
-    mc-panda-lirmm = prev.callPackage ./pkgs/mc-rtc/robots/mc-panda/mc-panda-lirmm.nix { };
-    mc-robogami = prev.callPackage ./pkgs/mc-rtc/robots/modules/mc-robogami.nix { };
-    mc-pepper = prev.callPackage ./pkgs/mc-rtc/robots/mc-pepper/mc-pepper.nix { };
+    mc-g1 = final.callPackage ./pkgs/mc-rtc/robots/modules/mc-g1.nix { };
+    mc-h1 = final.callPackage ./pkgs/mc-rtc/robots/modules/mc-h1.nix { };
+    mc-ur5e = final.callPackage ./pkgs/mc-rtc/robots/modules/mc-ur5e.nix { };
+    mc-human = final.callPackage ./pkgs/mc-rtc/robots/modules/mc-human.nix { };
+    mc-panda = final.callPackage ./pkgs/mc-rtc/robots/mc-panda { };
+    mc-panda-lirmm = final.callPackage ./pkgs/mc-rtc/robots/mc-panda/mc-panda-lirmm.nix { };
+    mc-robogami = final.callPackage ./pkgs/mc-rtc/robots/modules/mc-robogami.nix { };
+    mc-pepper = final.callPackage ./pkgs/mc-rtc/robots/mc-pepper/mc-pepper.nix { };
 
-    libfranka_0_9_2 = prev.callPackage ./pkgs/mc-rtc/robots/mc-panda/libfranka.nix { };
-    # mc-franka = prev.callPackage ./pkgs/mc-rtc/robots/mc-panda/mc-franka.nix {};
-    mc-franka = prev.callPackage ./pkgs/mc-rtc/robots/mc-panda/mc-franka.nix { };
-    mesh-sampling = prev.callPackage ./pkgs/mesh-sampling { };
-    # mesh-sampling = prev.callPackage ./pkgs/mesh-sampling {};
+    libfranka_0_9_2 = final.callPackage ./pkgs/mc-rtc/robots/mc-panda/libfranka.nix { };
+    # mc-franka = final.callPackage ./pkgs/mc-rtc/robots/mc-panda/mc-franka.nix {};
+    mc-franka = final.callPackage ./pkgs/mc-rtc/robots/mc-panda/mc-franka.nix { };
+    mesh-sampling = final.callPackage ./pkgs/mesh-sampling { };
+    # mesh-sampling = final.callPackage ./pkgs/mesh-sampling {};
 
     mc-rtc = callWithRos ./pkgs/mc-rtc/mc-rtc.nix {
+      inherit with-ros;
       with-python-bindings = with-python;
       with-python-tools = true;
       inherit qt;
@@ -124,18 +137,18 @@
     mc-rtc-ros-compat = callWithRos ./pkgs/mc-rtc/mc-rtc-ros-compat.nix {
       jrl-cmakemodules = final.jrl-cmakemodulesv2;
     };
-    mc-rtc-python-utils = prev.callPackage ./pkgs/mc-rtc/mc-rtc-python-utils.nix { };
+    mc-rtc-python-utils = final.callPackage ./pkgs/mc-rtc/mc-rtc-python-utils.nix { };
     #mc-rtc = callWithRos ./pkgs/mc-rtc/mc-rtc.nix {};
     # mc-rtc-rviz-panel = prev.libsForQt5.callPackage ./pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix { inherit useLocal; inherit localWorkspace; };
     mc-rtc-rviz-panel = prev.libsForQt5.callPackage ./pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix {
       inherit qt;
     };
-    # mc-rtc-ticker = prev.callPackage ./pkgs/mc-rtc/ros/mc-rtc-ticker.nix {};
-    mc-rtc-ticker = prev.callPackage ./pkgs/mc-rtc/ros/mc-rtc-ticker.nix { };
-    # mc-rtc = prev.callPackage ./pkgs/mc-rtc/mc-rtc.nix { with-ros = true; };
-    # mc-rtc = prev.callPackage ./pkgs/mc-rtc/mc-rtc.nix { };
-    # mc-rtc-magnum = prev.callPackage ./pkgs/mc-rtc-magnum {};
-    gram-savitzky-golay = prev.callPackage ./pkgs/gram-savitzky-golay { };
+    # mc-rtc-ticker = final.callPackage ./pkgs/mc-rtc/ros/mc-rtc-ticker.nix {};
+    mc-rtc-ticker = final.callPackage ./pkgs/mc-rtc/ros/mc-rtc-ticker.nix { };
+    # mc-rtc = final.callPackage ./pkgs/mc-rtc/mc-rtc.nix { with-ros = true; };
+    # mc-rtc = final.callPackage ./pkgs/mc-rtc/mc-rtc.nix { };
+    # mc-rtc-magnum = final.callPackage ./pkgs/mc-rtc-magnum {};
+    gram-savitzky-golay = final.callPackage ./pkgs/gram-savitzky-golay { };
 
     ##########
     #  Apps  #
@@ -144,23 +157,27 @@
       propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ final.libGL ];
     });
 
-    jvrc1-mj-description = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/jvrc1-mj-description.nix { };
-    g1-mj-description = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/g1-mj-description.nix { };
-    h1-mj-description = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/h1-mj-description.nix { };
-    ur5e-mj-description = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/ur5e-mj-description.nix { };
-    human-mj-description = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/human-mj-description.nix { };
+    jvrc1-mj-description =
+      final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/jvrc1-mj-description.nix
+        { };
+    g1-mj-description = final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/g1-mj-description.nix { };
+    h1-mj-description = final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/h1-mj-description.nix { };
+    ur5e-mj-description = final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/ur5e-mj-description.nix { };
+    human-mj-description =
+      final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/human-mj-description.nix
+        { };
 
-    env-mj-description = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/env-mj-description.nix { };
+    env-mj-description = final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/env-mj-description.nix { };
 
     # symlinkJoin all robots
     # FIXME: this triggers a full rebuild of mc-mujoco
-    mc-mujoco = prev.callPackage ./pkgs/mc-rtc/mc-mujoco {
+    mc-mujoco = final.callPackage ./pkgs/mc-rtc/mc-mujoco {
       jrl-cmakemodules = final.jrl-cmakemodulesv2;
     };
 
-    mc-mujoco-robots = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix { };
+    mc-mujoco-robots = final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix { };
     # mc-mujoco with all public robots
-    mc-mujoco-robots-public = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix {
+    mc-mujoco-robots-public = final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix {
       robots = with final; [
         g1-mj-description
         h1-mj-description
@@ -169,9 +186,9 @@
       ];
     };
 
-    mc-mujoco-full = prev.callPackage ./pkgs/mc-rtc/mc-mujoco {
+    mc-mujoco-full = final.callPackage ./pkgs/mc-rtc/mc-mujoco {
       jrl-cmakemodules = final.jrl-cmakemodulesv2;
-      mc-mujoco-robots = prev.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix {
+      mc-mujoco-robots = final.callPackage ./pkgs/mc-rtc/mc-mujoco/robots/default.nix {
         robots = final.mc-mujoco-robots-public.robots;
       };
     };
@@ -179,48 +196,48 @@
     ###############
     # CONTROLLERS #
     ###############
-    panda-prosthesis = prev.callPackage ./pkgs/mc-rtc/controllers/panda-prosthesis { };
-    # panda-prosthesis = prev.callPackage ./pkgs/mc-rtc/controllers/panda-prosthesis {};
+    panda-prosthesis = final.callPackage ./pkgs/mc-rtc/controllers/panda-prosthesis { };
+    # panda-prosthesis = final.callPackage ./pkgs/mc-rtc/controllers/panda-prosthesis {};
 
     ###########
     # PLUGINS #
     ###########
-    mc-force-shoe-plugin = prev.callPackage ./pkgs/mc-rtc/plugins/mc-force-shoe-plugin.nix { };
-    mc-robot-model-update = prev.callPackage ./pkgs/mc-rtc/plugins/mc-robot-model-update.nix { };
+    mc-force-shoe-plugin = final.callPackage ./pkgs/mc-rtc/plugins/mc-force-shoe-plugin.nix { };
+    mc-robot-model-update = final.callPackage ./pkgs/mc-rtc/plugins/mc-robot-model-update.nix { };
 
     #############
     # 3rd-party #
     #############
-    eigen-fmt = prev.callPackage ./pkgs/3rd-party/eigen-fmt {
+    eigen-fmt = final.callPackage ./pkgs/3rd-party/eigen-fmt {
       fmt = prev.fmt_10;
     };
 
-    imguizmo = prev.callPackage ./pkgs/3rd-party/imguizmo.nix {
+    imguizmo = final.callPackage ./pkgs/3rd-party/imguizmo.nix {
       jrl-cmakemodules = final.jrl-cmakemodulesv2;
     };
-    corrade = prev.callPackage ./pkgs/3rd-party/magnum/corrade.nix { };
-    magnum = prev.callPackage ./pkgs/3rd-party/magnum/magnum.nix { };
-    magnum-integration = prev.callPackage ./pkgs/3rd-party/magnum/magnum-integration.nix {
+    corrade = final.callPackage ./pkgs/3rd-party/magnum/corrade.nix { };
+    magnum = final.callPackage ./pkgs/3rd-party/magnum/magnum.nix { };
+    magnum-integration = final.callPackage ./pkgs/3rd-party/magnum/magnum-integration.nix {
       with-imguiintegration = true;
     };
-    magnum-plugins = prev.callPackage ./pkgs/3rd-party/magnum/magnum-plugins.nix {
+    magnum-plugins = final.callPackage ./pkgs/3rd-party/magnum/magnum-plugins.nix {
       magnumPluginsWithAssimpImporter = true;
       magnumPluginsWithStbImageImporter = true;
     };
-    magnum-with-plugins = prev.callPackage ./pkgs/3rd-party/magnum/magnum-with-plugins.nix { };
-    mc-rtc-imgui = prev.callPackage ./pkgs/mc-rtc-imgui {
+    magnum-with-plugins = final.callPackage ./pkgs/3rd-party/magnum/magnum-with-plugins.nix { };
+    mc-rtc-imgui = final.callPackage ./pkgs/mc-rtc-imgui {
       jrl-cmakemodules = final.jrl-cmakemodulesv2;
     };
     # standlone version of mc-rtc-magnum, with independent packaging for magnum and its plugins
     # and a standalone mc-rtc-imgui version
-    mc-rtc-magnum = prev.callPackage ./pkgs/mc-rtc-magnum/standalone.nix { };
+    mc-rtc-magnum = final.callPackage ./pkgs/mc-rtc-magnum/standalone.nix { };
 
-    sphinx-cmake = prev.callPackage ./pkgs/sphinx-cmake.nix { };
+    sphinx-cmake = final.callPackage ./pkgs/sphinx-cmake.nix { };
 
     ##########
     # TOOLS  #
     ##########
-    mc-robot-tools = prev.callPackage ./pkgs/mc-rtc/tools/mc-robot-tools.nix { };
+    mc-robot-tools = final.callPackage ./pkgs/mc-rtc/tools/mc-robot-tools.nix { };
 
     ##########
     # PYTHON #

--- a/pkgs/mc-rtc/controllers/ismpc-walking/footsteps-planner-plugin.nix
+++ b/pkgs/mc-rtc/controllers/ismpc-walking/footsteps-planner-plugin.nix
@@ -1,0 +1,37 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  mc-rtc,
+  jrl-cmakemodulesv2,
+}:
+
+stdenv.mkDerivation {
+  pname = "footsteps-planner-plugin";
+  version = "0.0.0";
+
+  # TODO: release
+  src = fetchFromGitHub {
+    owner = "isri-aist";
+    repo = "footsteps_planner";
+    rev = "0284df685b7ba0c5191a5cd1ca20fbcb2dc56850";
+    hash = "sha256-On3cRrJrzs20OLTWSWfVX1DGUUqSbePKxhYhTE9EThg=";
+  };
+
+  buildInputs = [ jrl-cmakemodulesv2 ];
+  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [
+    mc-rtc
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Linear Inverted Pendulum based footsteps location and steps timing adptation for Bipedal Locomotion.";
+    homepage = "https://github.com/antodld/pendulum_feasibility_solver";
+    # TODO: add licence
+    license = licenses.bsd2;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
+++ b/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
@@ -1,0 +1,53 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  jrl-cmakemodulesv2,
+  mc-rtc,
+  pendulum-feasibility-solver,
+  footsteps-planner-plugin,
+  mc-joystick-plugin,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ismpc-walking-controller";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "jrl-umi3218";
+    repo = "lipm_walking_controller";
+    tag = "v${version}";
+    hash = "sha256-tPWzbxuJbJm5zlUzU8jQJSdTIOsW8mb/Ci2DOeFdr4M=";
+  };
+
+  buildInputs = [ jrl-cmakemodulesv2 ];
+  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [
+    mc-rtc
+    pendulum-feasibility-solver
+    mc-joystick-plugin
+  ];
+
+  # XXX(mc-rtc-passthru)
+  passthru = {
+    mc-rtc.plugins = [
+      footsteps-planner-plugin
+      mc-joystick-plugin
+    ];
+  };
+
+  cmakeFlags = [
+    "-DINSTALL_DOCUMENTATION=OFF"
+    "-DMC_RTC_HONOR_INSTALL_PREFIX=ON"
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Walking controller based on linear inverted pendulum tracking";
+    homepage = "https://github.com/isri-aist/ismpc_walking";
+    license = licenses.bsd2;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/mc-rtc/controllers/ismpc-walking/mc-joystick-plugin.nix
+++ b/pkgs/mc-rtc/controllers/ismpc-walking/mc-joystick-plugin.nix
@@ -1,0 +1,37 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  jrl-cmakemodulesv2,
+  mc-rtc,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mc-joystick-plugin";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "isri-aist";
+    repo = "mc_joystick_plugin";
+    rev = "781db4266daf6346e270115c1908350d25c3ba0e";
+    hash = "sha256-YKnvYEeNFYNWdEGVoxhDlYXXCTkn0DlQYzbglB0pJNc=";
+  };
+
+  buildInputs = [ jrl-cmakemodulesv2 ];
+  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [
+    mc-rtc
+  ];
+
+  cmakeFlags = [ ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "";
+    homepage = "https://github.com/isri-aist/mc_joystick_plugin";
+    license = licenses.bsd2;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/mc-rtc/controllers/ismpc-walking/pendulum-feasibility-solver.nix
+++ b/pkgs/mc-rtc/controllers/ismpc-walking/pendulum-feasibility-solver.nix
@@ -1,0 +1,39 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  jrl-cmakemodulesv2,
+  spacevecalg,
+  eigen-quadprog,
+}:
+
+stdenv.mkDerivation {
+  pname = "pendulum-feasibility-solver";
+  version = "0.0.0";
+
+  # TODO: release
+  src = fetchFromGitHub {
+    owner = "isri-aist";
+    repo = "pendulum_feasibility_solver";
+    rev = "33552357cce4eb5a80e759be9e5c9a2c7f440126";
+    hash = "sha256-E8PKIHBZUkDA6OveDyq9d5d2Xk6kXxMrfA0RhIXRjlw=";
+  };
+
+  buildInputs = [ jrl-cmakemodulesv2 ];
+  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [
+    spacevecalg
+    eigen-quadprog
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Linear Inverted Pendulum based footsteps location and steps timing adptation for Bipedal Locomotion.";
+    homepage = "https://github.com/antodld/pendulum_feasibility_solver";
+    # TODO: add licence
+    license = licenses.bsd2;
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
- Fixes use of ccache, in particular with buildRosPackages
- Fixes overlays to always use the final overlay
- Enables ccache by default (let's see)

In addition: Adds ismpc-walking and related pkgs

After a bit of use:
```
Cacheable calls:    4475 / 6827 (65.55%)
  Hits:             1516 / 4475 (33.88%)
    Direct:         1000 / 1516 (65.96%)
    Preprocessed:    516 / 1516 (34.04%)
  Misses:           2959 / 4475 (66.12%)
Uncacheable calls:  2352 / 6827 (34.45%)
Local storage:
  Cache size (GiB):  2.3 /  5.0 (45.09%)
  Cleanups:          211
  Hits:             1516 / 4475 (33.88%)
  Misses:           2959 / 4475 (66.12%)
```
