### PR TITLE
Auto-generate mc-rtc-superbuild + fix ccache

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Presets are extensible with `extends` and merge with these semantics:
   - devel shell: devel components are added as `inputsFrom` and expected in `.superbuild/install`
 
 Conditional defaults:
-- ROS defaults (e.g. `mc-rtc-ticker`) are only added when `mc-rtc-nix.with-ros = true`
+- ROS defaults (e.g. `mc-rtc-rviz`) are only added when `mc-rtc-nix.with-ros = true`
 - private robots are only added to `full` when `mc-rtc-nix.overlays.private = true`
 
 Additional config fragments can be provided with `extraConfigFiles` (instead of overloading `config`).

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -11,10 +11,10 @@
 <!-- - [Defining `pkgs`](./pkgs.md) -->
 <!-- - [Generating your `packages` and `devShells`](./packages-devshells.md) -->
 <!-- - [Building everything in `checks`](./checks.md) -->
-<!---->
-<!-- # Lib -->
-<!---->
-<!-- - [Plain lib](./plain-lib.md) -->
+
+# Lib
+
+- [Plain lib](./plain-lib.md)
 <!-- - [Generated lib](./generated-lib.md) -->
 <!---->
 <!-- # HOWTOs -->
@@ -25,7 +25,7 @@
 <!-- <!-- # WIP --> -->
 <!-- <!----> -->
 <!-- <!-- - [Rationale](./rationale.md) --> -->
-<!---->
-<!-- --- -->
-<!---->
-<!-- [Full module options search](./search/index.html) -->
+
+---
+
+[Full module options search](./search/index.html)

--- a/docs/flake.lock
+++ b/docs/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "ccache-trigger": {
       "locked": {
-        "lastModified": 1657739266,
-        "narHash": "sha256-vLy8GQr0noEcoA+jX24FgUVBA/poV36zDWAUChN3hIY=",
+        "lastModified": 1657739253,
+        "narHash": "sha256-L9eyTL7njtPBUYmZRYFKCzQFDgua9U9oE7UwCzjZfl8=",
         "owner": "boolean-option",
-        "repo": "false",
-        "rev": "d06b4794a134686c70a1325df88a6e6768c6b212",
+        "repo": "true",
+        "rev": "6ecb49143ca31b140a5273f1575746ba93c3f698",
         "type": "github"
       },
       "original": {
         "owner": "boolean-option",
-        "repo": "false",
+        "repo": "true",
         "type": "github"
       }
     },
@@ -34,22 +34,6 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_3": {
-      "flake": false,
-      "locked": {
         "lastModified": 1696426674,
         "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
@@ -68,11 +52,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -103,49 +87,6 @@
       "inputs": {
         "nixpkgs-lib": [
           "mc-rtc-nix",
-          "gepetto",
-          "system-manager",
-          "userborn",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1768135262,
-        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_4": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_3"
-      },
-      "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_5": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
           "gepetto",
           "system-manager",
           "userborn",
@@ -220,24 +161,6 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
-      "inputs": {
-        "systems": "systems_6"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "flakoboros": {
       "inputs": {
         "flake-parts": "flake-parts",
@@ -256,11 +179,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1782382954,
-        "narHash": "sha256-fVbu+XabaPkC44klgk5rTRPZHLzkh2su5zsaR660mps=",
+        "lastModified": 1784343123,
+        "narHash": "sha256-7uNNffJd8sPow9pHU5VY7zN7mFTwAUOToZZSibpJDRo=",
         "owner": "Gepetto",
         "repo": "flakoboros",
-        "rev": "8d471805dfe7e618b3fe33f7cb9dd0b1b52d2e54",
+        "rev": "cb63c52cd536e2e684520cfa63169d4cedb54f05",
         "type": "github"
       },
       "original": {
@@ -293,50 +216,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1781324212,
-        "narHash": "sha256-lqIEMqeuJ450S7JdWTo8JjF3YlahGNR2FCz/AlA9ZhM=",
+        "lastModified": 1782042109,
+        "narHash": "sha256-oDCl/rcvJVTcf6G2ag3YdZSMHDVBBmoXTysY5yzq+Dk=",
         "owner": "gepetto",
         "repo": "flakoboros",
-        "rev": "78aa318051a5345d82931df66c5c8d0844edcb2a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "gepetto",
-        "repo": "flakoboros",
-        "type": "github"
-      }
-    },
-    "flakoboros_3": {
-      "inputs": {
-        "flake-parts": "flake-parts_4",
-        "nix-ros-overlay": "nix-ros-overlay_3",
-        "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "nix-ros-overlay",
-          "nixpkgs"
-        ],
-        "systems": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "nix-ros-overlay",
-          "flake-utils",
-          "systems"
-        ],
-        "treefmt-nix": "treefmt-nix_3"
-      },
-      "locked": {
-        "lastModified": 1776113076,
-        "narHash": "sha256-rQp/6mgQc4szevay50RbGXOXwL3xC7oHktywFPrmbAM=",
-        "owner": "gepetto",
-        "repo": "flakoboros",
-        "rev": "07a89fe2a47f2f0364e795cf3e69c045de14a3b2",
+        "rev": "fc7d44063fa05f1a78c97c63b124c1da2862331c",
         "type": "github"
       },
       "original": {
@@ -371,6 +255,13 @@
         ],
         "pyproject-build-systems": "pyproject-build-systems",
         "pyproject-nix": "pyproject-nix",
+        "rosdistro": [
+          "mc-rtc-nix",
+          "gepetto",
+          "gazebros2nix",
+          "nix-ros-overlay",
+          "rosdistro"
+        ],
         "systems": [
           "mc-rtc-nix",
           "gepetto",
@@ -388,72 +279,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1781362845,
-        "narHash": "sha256-IxhhDOW/aLRltOGHiYTP+Oqr2baRPqtrJYIVvfuw5aE=",
+        "lastModified": 1783519093,
+        "narHash": "sha256-ah05yiNKtTipRI1rseMOfqXCTaqEX5TM+o9lz3IQd+M=",
         "owner": "gepetto",
         "repo": "gazebros2nix",
-        "rev": "f45bbdedc06ae9060a14834ee2896199f979d062",
-        "type": "github"
-      },
-      "original": {
-        "owner": "gepetto",
-        "repo": "gazebros2nix",
-        "type": "github"
-      }
-    },
-    "gazebros2nix_2": {
-      "inputs": {
-        "flake-parts": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "flake-parts"
-        ],
-        "flakoboros": "flakoboros_3",
-        "nix-ros-overlay": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "nix-ros-overlay"
-        ],
-        "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "nixpkgs"
-        ],
-        "pyproject-build-systems": "pyproject-build-systems_2",
-        "pyproject-nix": "pyproject-nix_2",
-        "systems": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "systems"
-        ],
-        "treefmt-nix": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "treefmt-nix"
-        ],
-        "uv2nix": "uv2nix_2"
-      },
-      "locked": {
-        "lastModified": 1777754176,
-        "narHash": "sha256-bnR2Aor+qSLVCcUUV/IjjHM5AnJR6cpf0AljUSiUuco=",
-        "owner": "gepetto",
-        "repo": "gazebros2nix",
-        "rev": "29d82bf45d91a5e9ca9f8c40f963ad20168e6ae1",
+        "rev": "662fcd41e6bab21ef6cce4e9e3d0a4e6221961dc",
         "type": "github"
       },
       "original": {
@@ -506,74 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781410865,
-        "narHash": "sha256-EC0VzThwka/bPooGIN63c8dEXVaEshw61bm5lNYmI54=",
+        "lastModified": 1784295348,
+        "narHash": "sha256-hZYhxeG510Ui/RSviEM7KyON8RiQoHFD7SY3y4+1zKA=",
         "owner": "gepetto",
         "repo": "nix",
-        "rev": "ae989cac5c2b3f51131dd54b8fb949ee1b7b2563",
-        "type": "github"
-      },
-      "original": {
-        "owner": "gepetto",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
-    "gepetto_2": {
-      "inputs": {
-        "flake-parts": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flake-parts"
-        ],
-        "flakoboros": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros"
-        ],
-        "gazebros2nix": "gazebros2nix_2",
-        "home-manager": "home-manager_2",
-        "nix-ros-overlay": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "nix-ros-overlay"
-        ],
-        "nix-system-graphics": "nix-system-graphics_2",
-        "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "nixpkgs"
-        ],
-        "system-manager": "system-manager_2",
-        "systems": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "systems"
-        ],
-        "treefmt-nix": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "treefmt-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777773493,
-        "narHash": "sha256-6zivX47/UVo1dR9iGNRBETvz7/igFrc2SrqCbJqxtWY=",
-        "owner": "gepetto",
-        "repo": "nix",
-        "rev": "506ba63b0f3f7f1b1ac5e215f957feb4b12013d6",
+        "rev": "166caeac8f09def7818c47bbfcc08777c2c3fbc4",
         "type": "github"
       },
       "original": {
@@ -586,32 +353,6 @@
       "inputs": {
         "nixpkgs": [
           "mc-rtc-nix",
-          "gepetto",
-          "system-manager",
-          "userborn",
-          "pre-commit-hooks-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_2": {
-      "inputs": {
-        "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
           "gepetto",
           "system-manager",
           "userborn",
@@ -656,52 +397,30 @@
         "type": "github"
       }
     },
-    "home-manager_2": {
+    "jrl-cmakemodulesv2": {
       "inputs": {
-        "nixpkgs": [
+        "gepetto": [
           "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "nixpkgs"
+          "gepetto"
         ]
       },
       "locked": {
-        "lastModified": 1777771528,
-        "narHash": "sha256-YycygK6n7KeW1YCobdFJcORWzkmrvNcp6xT+IovA0d4=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "0585fbf645640973e3398863bbaf3bd1ddce4a51",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "release-25.11",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "jrl-cmakemodulesv2": {
-      "inputs": {
-        "gepetto": "gepetto_2"
-      },
-      "locked": {
-        "lastModified": 1781271796,
-        "narHash": "sha256-ib/hYwNKA5ibWn7ufQ45Gy+VRKNfR552xkr80OsCPhk=",
-        "owner": "ahoarau",
+        "lastModified": 1783605492,
+        "narHash": "sha256-CJPPNoyLYZJkaC0X8yxxY+jw7fUpN67tWQ7mdZlMvNc=",
+        "owner": "jrl-umi3218",
         "repo": "jrl-cmakemodules",
-        "rev": "4cfa6b85b49e5b6b2e0f02a9076892afd1050fb1",
+        "rev": "e33225ea9330bf7217a2e38852d8a38ae028085f",
         "type": "github"
       },
       "original": {
-        "owner": "ahoarau",
-        "ref": "jrl-next",
+        "owner": "jrl-umi3218",
         "repo": "jrl-cmakemodules",
         "type": "github"
       }
     },
     "make-shell": {
       "inputs": {
-        "flake-compat": "flake-compat_3"
+        "flake-compat": "flake-compat_2"
       },
       "locked": {
         "lastModified": 1733933815,
@@ -764,11 +483,11 @@
         "rosdistro": "rosdistro"
       },
       "locked": {
-        "lastModified": 1781900693,
-        "narHash": "sha256-4KFk+S9ZbMonItYsdPtZjwESsgrCEpXGDa6rosDxLGs=",
+        "lastModified": 1783677431,
+        "narHash": "sha256-uNuOIHOYSHWGIJROHA9lO4OLxlpNJBf+siMPnsFD/b0=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "fb296510db68c2e760980ab8c6daf6ded9060213",
+        "rev": "2cf3f711656d8967142bbdf315821ecdb03a7361",
         "type": "github"
       },
       "original": {
@@ -785,11 +504,11 @@
         "rosdistro": "rosdistro_2"
       },
       "locked": {
-        "lastModified": 1781297240,
-        "narHash": "sha256-OpYxlrSlcqJyknjgIuvv8dtEEbHuuZoe+fJzclrBgmg=",
+        "lastModified": 1781900693,
+        "narHash": "sha256-4KFk+S9ZbMonItYsdPtZjwESsgrCEpXGDa6rosDxLGs=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "9e9b9a2953a195985e1e6c99e353fbb767380a2d",
+        "rev": "fb296510db68c2e760980ab8c6daf6ded9060213",
         "type": "github"
       },
       "original": {
@@ -802,35 +521,15 @@
     "nix-ros-overlay_3": {
       "inputs": {
         "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1775764892,
-        "narHash": "sha256-l1UbHppd5KaU4K/TQPIXf9wnVifH4Tgrx5z2GFoq/bw=",
-        "owner": "lopsided98",
-        "repo": "nix-ros-overlay",
-        "rev": "0a4e8cf51001d2d1c613f95dadd3853da42c0164",
-        "type": "github"
-      },
-      "original": {
-        "owner": "lopsided98",
-        "ref": "develop",
-        "repo": "nix-ros-overlay",
-        "type": "github"
-      }
-    },
-    "nix-ros-overlay_4": {
-      "inputs": {
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "rosdistro": "rosdistro_3"
       },
       "locked": {
-        "lastModified": 1782424179,
-        "narHash": "sha256-slrmIubTfU/BolYHI6QdVpWzYWlhVV96EsAbaxRpYnU=",
+        "lastModified": 1784365802,
+        "narHash": "sha256-gIo2tpI/EOEPk+lkCJ9ToNcFIcR0Yl+hUeVh0C8PwAE=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "fbba1e98610310509e36e4c658550519d5b2e8d6",
+        "rev": "cb798e1cd2804cdfc306af91d3eb9d4f27ec3d06",
         "type": "github"
       },
       "original": {
@@ -862,36 +561,13 @@
         "type": "github"
       }
     },
-    "nix-system-graphics_2": {
-      "inputs": {
-        "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1763296639,
-        "narHash": "sha256-K9JBscC7ApwCnl0wR0sVkxrKFsoDYVqXN5fOujvyBWA=",
-        "owner": "soupglasses",
-        "repo": "nix-system-graphics",
-        "rev": "ac37f0f3ec0cb15d63a520918433c794d01d9dac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "soupglasses",
-        "repo": "nix-system-graphics",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {
@@ -903,11 +579,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -923,21 +599,6 @@
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
         "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib_3": {
-      "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
         "type": "github"
       },
       "original": {
@@ -964,27 +625,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1771369470,
-        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0182a361324364ae3f436a63005877674cf45efb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {
@@ -1006,40 +651,6 @@
         "gitignore": "gitignore",
         "nixpkgs": [
           "mc-rtc-nix",
-          "gepetto",
-          "system-manager",
-          "userborn",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769069492,
-        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks-nix_2": {
-      "inputs": {
-        "flake-compat": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "system-manager",
-          "userborn",
-          "flake-compat"
-        ],
-        "gitignore": "gitignore_2",
-        "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
           "gepetto",
           "system-manager",
           "userborn",
@@ -1097,49 +708,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779676664,
-        "narHash": "sha256-MbXylBTkWqVm8/VYjoULtMoVRgWBN1gSHbeRKsOsPlU=",
+        "lastModified": 1782093830,
+        "narHash": "sha256-6gmEVe69+KlRkZD4PEEV5xAlB9CB0Y9TiuEgQjDrKTQ=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "7bff980f37fc24e09dbc986643719900c139bf12",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "build-system-pkgs",
-        "type": "github"
-      }
-    },
-    "pyproject-build-systems_2": {
-      "inputs": {
-        "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "nixpkgs"
-        ],
-        "pyproject-nix": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "pyproject-nix"
-        ],
-        "uv2nix": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "uv2nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776659114,
-        "narHash": "sha256-qapCOQmR++yZSY43dzrp3wCrkOTLpod+ONtJWBk6iKU=",
-        "owner": "pyproject-nix",
-        "repo": "build-system-pkgs",
-        "rev": "ffaa2161dd5d63e0e94591f86b54fc239660fb2e",
+        "rev": "430680a19bc85a3bda55f12e4cc1a1aadcf2e478",
         "type": "github"
       },
       "original": {
@@ -1158,35 +731,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780416763,
-        "narHash": "sha256-rRK3IFixgsrK6S3e14Xz9HAZm7+kMAIl3oi5zZlcwYI=",
+        "lastModified": 1782905613,
+        "narHash": "sha256-SvXJcAemihifkTn4BGvyE5K1FJX9bl4U8DQ5pqKvD0s=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "ad83f1ead0e78e57b188f35cb57298affb06fc5f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "type": "github"
-      }
-    },
-    "pyproject-nix_2": {
-      "inputs": {
-        "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776715674,
-        "narHash": "sha256-Gs1VnEkCkkRZxJQAC/Dhz0Jbfi22mFXChbtNg9w/Ybg=",
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "rev": "69f57f27e52a87c54e28138a75ec741cd46663c9",
+        "rev": "7af23cfe91064865ecf2e835da28b45b3c6f49fd",
         "type": "github"
       },
       "original": {
@@ -1203,7 +752,7 @@
         ],
         "flakoboros": "flakoboros",
         "mc-rtc-nix": "mc-rtc-nix",
-        "nix-ros-overlay": "nix-ros-overlay_4",
+        "nix-ros-overlay": "nix-ros-overlay_3",
         "nixpkgs": [
           "nix-ros-overlay",
           "nixpkgs"
@@ -1215,6 +764,22 @@
       }
     },
     "rosdistro": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782470688,
+        "narHash": "sha256-9MkdEHS6wGHb1PyHyBuHIHKGA7z//1nBB+zXOq5F3Wc=",
+        "owner": "ros",
+        "repo": "rosdistro",
+        "rev": "27f5821b9025f00cecf2936dd6698788fc87cf6a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ros",
+        "repo": "rosdistro",
+        "type": "github"
+      }
+    },
+    "rosdistro_2": {
       "flake": false,
       "locked": {
         "lastModified": 1781238695,
@@ -1230,30 +795,14 @@
         "type": "github"
       }
     },
-    "rosdistro_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1780665549,
-        "narHash": "sha256-QzobMKNpcpS4uWETzPxXkt0F66Sji15N+xsK1JcEWDU=",
-        "owner": "ros",
-        "repo": "rosdistro",
-        "rev": "bcec45c05427f0ad6860cb323695995d8cb1e4bd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ros",
-        "repo": "rosdistro",
-        "type": "github"
-      }
-    },
     "rosdistro_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1781869206,
-        "narHash": "sha256-R4z1i9ud5wCUuyYgr+F+bLP0cMJgjk6/y/OiT5iSRJs=",
+        "lastModified": 1782470688,
+        "narHash": "sha256-9MkdEHS6wGHb1PyHyBuHIHKGA7z//1nBB+zXOq5F3Wc=",
         "owner": "ros",
         "repo": "rosdistro",
-        "rev": "f650d990cad69b0898e83e636c09863f05a0b08c",
+        "rev": "27f5821b9025f00cecf2936dd6698788fc87cf6a",
         "type": "github"
       },
       "original": {
@@ -1278,31 +827,6 @@
         "owner": "numtide",
         "repo": "system-manager",
         "rev": "dc1baae12eed1758755e73f8aff7fca5502c6e9f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "system-manager",
-        "type": "github"
-      }
-    },
-    "system-manager_2": {
-      "inputs": {
-        "flake-compat": "flake-compat_2",
-        "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "nixpkgs"
-        ],
-        "userborn": "userborn_2"
-      },
-      "locked": {
-        "lastModified": 1777545354,
-        "narHash": "sha256-T3u9Ixg0SX6bYYXHYEZ7O+MW0pQ1qxnjIQKCPM+irN4=",
-        "owner": "numtide",
-        "repo": "system-manager",
-        "rev": "6eac5ac077960363d3807b1c74f47103d1f62efd",
         "type": "github"
       },
       "original": {
@@ -1371,36 +895,6 @@
         "type": "github"
       }
     },
-    "systems_5": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_6": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
@@ -1446,31 +940,6 @@
         "type": "github"
       }
     },
-    "treefmt-nix_3": {
-      "inputs": {
-        "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
     "userborn": {
       "inputs": {
         "flake-compat": [
@@ -1504,41 +973,6 @@
         "type": "github"
       }
     },
-    "userborn_2": {
-      "inputs": {
-        "flake-compat": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "system-manager",
-          "flake-compat"
-        ],
-        "flake-parts": "flake-parts_5",
-        "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "system-manager",
-          "nixpkgs"
-        ],
-        "pre-commit-hooks-nix": "pre-commit-hooks-nix_2",
-        "systems": "systems_5"
-      },
-      "locked": {
-        "lastModified": 1770377964,
-        "narHash": "sha256-q2pnlX2IW0kg80GLFnwWd/GigIpkuZnyKPLhrgJql3E=",
-        "owner": "jfroche",
-        "repo": "userborn",
-        "rev": "55c2cd7952c207a62736a5bbd9499ea73da18d24",
-        "type": "github"
-      },
-      "original": {
-        "owner": "jfroche",
-        "ref": "system-manager",
-        "repo": "userborn",
-        "type": "github"
-      }
-    },
     "uv2nix": {
       "inputs": {
         "nixpkgs": [
@@ -1555,42 +989,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781249037,
-        "narHash": "sha256-Us5r9461lhAZ0cR4oTf7NQuNbp8ETFu0d683AF3mIPE=",
+        "lastModified": 1783511944,
+        "narHash": "sha256-Z/Ss9rWw9QYcRK+Qqkmty7PB1pIik5XGbrtit+ad2qs=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "ca656fb2cf1c2834e83413c7b2caa2b2d0c2b366",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
-        "type": "github"
-      }
-    },
-    "uv2nix_2": {
-      "inputs": {
-        "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "nixpkgs"
-        ],
-        "pyproject-nix": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "pyproject-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777463177,
-        "narHash": "sha256-1PcD0+IZPQXyvmXJ1OYH+23sRc9IyOKrUUBYZonVBm8=",
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
-        "rev": "6c53dcf4d3f63240f57e0b0c826cb15eda61f249",
+        "rev": "83995ef5e4ece3c9c704aa645bbff439e15a0ac3",
         "type": "github"
       },
       "original": {

--- a/docs/flake.lock
+++ b/docs/flake.lock
@@ -525,11 +525,11 @@
         "rosdistro": "rosdistro_3"
       },
       "locked": {
-        "lastModified": 1784365802,
-        "narHash": "sha256-gIo2tpI/EOEPk+lkCJ9ToNcFIcR0Yl+hUeVh0C8PwAE=",
+        "lastModified": 1784411287,
+        "narHash": "sha256-oQnBcy+usVzedG8/dsbScEAAKyMJ0nLQHizKfDC1jdU=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "cb798e1cd2804cdfc306af91d3eb9d4f27ec3d06",
+        "rev": "f092cd397fd167ae95ed7e0771f35ae88e519339",
         "type": "github"
       },
       "original": {
@@ -798,11 +798,11 @@
     "rosdistro_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1782470688,
-        "narHash": "sha256-9MkdEHS6wGHb1PyHyBuHIHKGA7z//1nBB+zXOq5F3Wc=",
+        "lastModified": 1784293198,
+        "narHash": "sha256-PYYpx0kwwNGlzRKZW28XfwU7S/J9S3yDp9acpDILhIA=",
         "owner": "ros",
         "repo": "rosdistro",
-        "rev": "27f5821b9025f00cecf2936dd6698788fc87cf6a",
+        "rev": "c8b19e9ae58b9eee6eedbd305720825646102334",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "ccache-trigger": {
       "locked": {
-        "lastModified": 1657739266,
-        "narHash": "sha256-vLy8GQr0noEcoA+jX24FgUVBA/poV36zDWAUChN3hIY=",
+        "lastModified": 1657739253,
+        "narHash": "sha256-L9eyTL7njtPBUYmZRYFKCzQFDgua9U9oE7UwCzjZfl8=",
         "owner": "boolean-option",
-        "repo": "false",
-        "rev": "d06b4794a134686c70a1325df88a6e6768c6b212",
+        "repo": "true",
+        "rev": "6ecb49143ca31b140a5273f1575746ba93c3f698",
         "type": "github"
       },
       "original": {
         "owner": "boolean-option",
-        "repo": "false",
+        "repo": "true",
         "type": "github"
       }
     },
@@ -185,11 +185,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1782566589,
-        "narHash": "sha256-vXVLP31bnnk8KUBUV88Ms2R6P06wdQPZzsXgR6iZ5FI=",
+        "lastModified": 1783519093,
+        "narHash": "sha256-ah05yiNKtTipRI1rseMOfqXCTaqEX5TM+o9lz3IQd+M=",
         "owner": "gepetto",
         "repo": "gazebros2nix",
-        "rev": "6e51068e9e9fec8e960f68911127ad64b417bf6b",
+        "rev": "662fcd41e6bab21ef6cce4e9e3d0a4e6221961dc",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783001154,
-        "narHash": "sha256-kPrfWL8YePlBRv0Sz2J4Uwn6C/HlhM3WZG96Y6TEqeU=",
+        "lastModified": 1784295348,
+        "narHash": "sha256-hZYhxeG510Ui/RSviEM7KyON8RiQoHFD7SY3y4+1zKA=",
         "owner": "gepetto",
         "repo": "nix",
-        "rev": "7a2bf9834c160a05872d0f77eeadc9362cb6f014",
+        "rev": "166caeac8f09def7818c47bbfcc08777c2c3fbc4",
         "type": "github"
       },
       "original": {
@@ -492,11 +492,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782089418,
-        "narHash": "sha256-LRD1SuQWr49fGq3A+8GLXfsLE2xqIpQA440YDZwms3M=",
+        "lastModified": 1782905613,
+        "narHash": "sha256-SvXJcAemihifkTn4BGvyE5K1FJX9bl4U8DQ5pqKvD0s=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "43f0b40edd0a74c63f66b7b48d969ae6b740d611",
+        "rev": "7af23cfe91064865ecf2e835da28b45b3c6f49fd",
         "type": "github"
       },
       "original": {
@@ -669,11 +669,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781810314,
-        "narHash": "sha256-PQfvfKWaBvCysdHFUO5GewwvwIqI/WL6OcrJhDSUdbc=",
+        "lastModified": 1783511944,
+        "narHash": "sha256-Z/Ss9rWw9QYcRK+Qqkmty7PB1pIik5XGbrtit+ad2qs=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "14aa44100859a44144878fe079f8089d3fa4dc4e",
+        "rev": "83995ef5e4ece3c9c704aa645bbff439e15a0ac3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -54,68 +54,74 @@
           ];
         });
     in
-    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = import inputs.systems;
-      imports = [
-        flakeModule
-        {
-          mc-rtc-nix = {
-            packages = true;
-            with-ros = inputTriggers.with-ros;
-            with-python = inputTriggers.with-python;
-            # gepetto.packages = true;
-            # gepetto.devShells = true;
-            overlays = {
-              private = inputTriggers.buildPrivate;
-              ccache = inputTriggers.ccache;
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } (
+      { lib, ... }:
+      {
+        systems = import inputs.systems;
+        imports = [
+          flakeModule
+          {
+            mc-rtc-nix = {
+              packages = true;
+              with-ros = inputTriggers.with-ros;
+              with-python = inputTriggers.with-python;
+              # gepetto.packages = true;
+              # gepetto.devShells = true;
+              overlays = {
+                private = inputTriggers.buildPrivate;
+                ccache = inputTriggers.ccache;
+              };
+            };
+            mc-rtc-superbuild = {
+              enable = true;
+              shells.defaultShells.release = true;
+            };
+          }
+        ];
+
+        flake = {
+          inherit flakeModule;
+
+          lib = import ./lib { inherit lib; } // {
+
+            # lib.mkFlakoboros
+            #   Usage: lib.mkFlakoboros localInputs module
+            #   Description: Creates a flake using the default flakeModule (public, with-ros).
+            #   Arguments:
+            #     - localInputs: The flake inputs set.
+            #     - flakoborosModule: The flake-parts module to use.
+            #                         See https://gepetto.github.io/flakoboros/index.html
+            mkFlakoboros =
+              localInputs: flakoborosModule: mkFlakoboros { inherit localInputs; } flakoborosModule;
+          };
+
+          templates = {
+            default = {
+              path = ./templates/default;
+              description = "A template for use with mc-rtc/nixpkgs";
+            };
+            controller = {
+              path = ./templates/controller;
+              description = "A template with superbuild configuration for use with mc-rtc/nixpkgs";
+            };
+            flakoboros = {
+              path = ./templates/flakoboros;
+              description = "A flakoboros template for simple projects";
+            };
+            flakoboros-new-package = {
+              path = ./templates/flakoboros-new-package;
+              description = "A flakoboros template for simple projects";
+            };
+            flakoboros-new-cpp-package = {
+              path = ./templates/flakoboros-new-cpp-package;
+              description = "A flakoboros template for C++ projects (cmake + catch2 + jrl-cmakemodules)";
+            };
+            ros = {
+              path = ./templates/ros;
+              description = "A template for use with mc-rtc/nixpkgs and ROS";
             };
           };
-          mc-rtc-superbuild = {
-            enable = true;
-            shells.defaultShells.release = true;
-          };
-        }
-      ];
-
-      flake = {
-        inherit flakeModule;
-
-        # lib.mkFlakoboros
-        #   Usage: lib.mkFlakoboros localInputs module
-        #   Description: Creates a flake using the default flakeModule (public, with-ros).
-        #   Arguments:
-        #     - localInputs: The flake inputs set.
-        #     - flakoborosModule: The flake-parts module to use.
-        #                         See https://gepetto.github.io/flakoboros/index.html
-        lib.mkFlakoboros =
-          localInputs: flakoborosModule: mkFlakoboros { inherit localInputs; } flakoborosModule;
-
-        templates = {
-          default = {
-            path = ./templates/default;
-            description = "A template for use with mc-rtc/nixpkgs";
-          };
-          controller = {
-            path = ./templates/controller;
-            description = "A template with superbuild configuration for use with mc-rtc/nixpkgs";
-          };
-          flakoboros = {
-            path = ./templates/flakoboros;
-            description = "A flakoboros template for simple projects";
-          };
-          flakoboros-new-package = {
-            path = ./templates/flakoboros-new-package;
-            description = "A flakoboros template for simple projects";
-          };
-          flakoboros-new-cpp-package = {
-            path = ./templates/flakoboros-new-cpp-package;
-            description = "A flakoboros template for C++ projects (cmake + catch2 + jrl-cmakemodules)";
-          };
-          ros = {
-            path = ./templates/ros;
-            description = "A template for use with mc-rtc/nixpkgs and ROS";
-          };
         };
-      };
-    };
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -46,14 +46,50 @@
           localInputs,
           localFlakeModule ? flakeModule,
         }:
-        flakoborosModule:
+        mcRtcFlakeModule:
         inputs.flake-parts.lib.mkFlake { inputs = localInputs; } (args: {
           systems = import inputs.systems;
           imports = [
             localFlakeModule
-            { flakoboros = flakoborosModule args; }
+            { flakoboros = mcRtcFlakeModule args; }
           ];
         });
+
+      mkMcRtcModule =
+        {
+          localInputs,
+          defaultAttrs ? { },
+          localFlakeModule ? flakeModule, # mc-rtc-nix flakeModule
+        }:
+        mcRtcFlakeModule:
+        inputs.flake-parts.lib.mkFlake { inputs = localInputs; } (args: {
+          systems = import inputs.systems;
+          imports = [
+            localFlakeModule # inputs.mc-rtc-nix.flakeModule
+            ((mcRtcFlakeModule args) // defaultAttrs)
+          ];
+        });
+
+      mkMcRtcController =
+        {
+          localInputs,
+          controllerName,
+          mkControllerSuperbuild,
+          localFlakeModule ? flakeModule, # mc-rtc-nix flakeModule
+        }:
+        mkMcRtcModule {
+          inherit localInputs localFlakeModule;
+          defaultAttrs = {
+            mc-rtc-superbuild =
+              { pkgs, ... }:
+              {
+                enable = true;
+                configurations = {
+                  "${controllerName}" = (mkControllerSuperbuild pkgs (builtins.getAttr controllerName pkgs) { });
+                };
+              };
+          };
+        };
     in
     inputs.flake-parts.lib.mkFlake { inherit inputs; } (
       { lib, ... }:
@@ -83,18 +119,51 @@
         flake = {
           inherit flakeModule;
 
-          lib = import ./lib { inherit lib; } // {
+          lib =
+            let
+              mc-rtc-lib = import ./lib { inherit lib; };
+            in
+            mc-rtc-lib
+            // {
+              # lib.mkFlakoboros
+              #   Usage: lib.mkFlakoboros localInputs module
+              #   Description: Creates a flake using the default flakeModule
+              #   Arguments:
+              #     - localInputs: The flake inputs set.
+              #     - flakoborosModule: The flake-parts module to use.
+              #                         See https://gepetto.github.io/flakoboros/index.html
+              mkFlakoboros =
+                localInputs: flakoborosModule:
+                builtins.trace "mkFlakoboros is deprecated, please use mkMcRtcModule instead" mkFlakoboros {
+                  inherit localInputs;
+                } flakoborosModule;
 
-            # lib.mkFlakoboros
-            #   Usage: lib.mkFlakoboros localInputs module
-            #   Description: Creates a flake using the default flakeModule (public, with-ros).
-            #   Arguments:
-            #     - localInputs: The flake inputs set.
-            #     - flakoborosModule: The flake-parts module to use.
-            #                         See https://gepetto.github.io/flakoboros/index.html
-            mkFlakoboros =
-              localInputs: flakoborosModule: mkFlakoboros { inherit localInputs; } flakoborosModule;
-          };
+              # lib.mkMcRtcModule
+              #   Usage: lib.mkFlakoboros localInputs module
+              #   Description: Creates a flake using the default flakeModule (public, with-ros).
+              #   Arguments:
+              #     - localInputs: The flake inputs set.
+              #     - flakoborosModule: The flake-parts module to use.
+              #                         See https://gepetto.github.io/flakoboros/index.html
+              mkMcRtcModule = localInputs: mcRtcModule: mkMcRtcModule { inherit localInputs; } mcRtcModule;
+
+              # lib.mkMcRtcController
+              #   Same as mkMcRtcModule but adds a default configuration for the controller (defined in ${controller}.passthru.mc-rtc)
+              #   Usage: lib.mkMcRtcController localInputs "controller-name" module
+              #   Description: Creates a flake using the default flakeModule and configures mc-rtc-superbuild with
+              #      a default configuration for the controller (defined in ${controller}.passthru.mc-rtc)
+              #   Arguments:
+              #     - localInputs: The flake inputs set.
+              #     - controllerName: Name of the controller
+              #     - flakoborosModule: The flake-parts module to use.
+              #                         See https://gepetto.github.io/flakoboros/index.html
+              mkMcRtcController =
+                localInputs: controllerName: flakoborosModule:
+                mkMcRtcController {
+                  inherit localInputs controllerName;
+                  mkControllerSuperbuild = mc-rtc-lib.mkControllerSuperbuild;
+                } flakoborosModule;
+            };
 
           templates = {
             default = {

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
   };
 
   outputs =
-    inputs:
+    { self, ... }@inputs:
     let
       flakeModule = inputs.flake-parts.lib.importApply ./module.nix {
         inherit (inputs)
@@ -32,6 +32,7 @@
           jrl-cmakemodulesv2
           make-shell
           ;
+        mc-rtc-lib = self.lib;
       };
       inputTriggers = {
         buildPrivate = inputs.private-trigger.value or false;

--- a/flake.nix
+++ b/flake.nix
@@ -172,7 +172,11 @@
             };
             controller = {
               path = ./templates/controller;
-              description = "A template with superbuild configuration for use with mc-rtc/nixpkgs";
+              description = "Simplified template with an auto-generated mc-rtc-superbuild configuration to build a controller";
+            };
+            superbuild = {
+              path = ./templates/superbuild;
+              description = "A template with a manual mc-rtc-superbuild configuration";
             };
             flakoboros = {
               path = ./templates/flakoboros;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   ...
 }:
 rec {
@@ -7,41 +8,128 @@ rec {
   # pkgs = packages.x86_64-linux
 
   /**
-    Converts a list of strings or derivations into a list of derivations from pkgs.
+    Converts a list of strings or derivations into a list of derivations from `pkgs`.
 
     Arguments:
-      pkgs: The package set to resolve string names to derivations.
-      vals: A list of strings (attribute names) or derivations.
 
-    Example:
-      lib.convertListToDrvs pkgs [ pkgs.human-mj-description "human-mj-description" ]
+    - `pkgs`: The package set to resolve string names to derivations.
+    - `vals`: A list of strings (attribute names) or derivations.
+    - `ignoreMissing` (optional, default: `false`): If true, missing derivations are skipped with a warning.
 
-    Type: pkgs: AttrSet -> vals: [ String | Derivation ] -> [ Derivation ]
+    Returns:
+
+    - A list of derivations, resolving strings via `pkgs`.
+
+    @example
+    ```nix
+    lib._convertListToDrvs {
+      pkgs = pkgs;
+      vals = [ pkgs.human-mj-description "human-mj-description" ];
+    }
+    ```
+
+    Type:
+      { pkgs: AttrSet, vals: [String | Derivation], ignoreMissing?: Bool } -> [Derivation]
+  */
+  _convertListToDrvs =
+    {
+      pkgs,
+      vals,
+      ignoreMissing ? false,
+    }:
+    let
+      toDrv =
+        x:
+        if builtins.isAttrs x && x ? type && x.type == "derivation" then
+          x
+        else if builtins.isString x then
+          if builtins.hasAttr x pkgs then
+            builtins.getAttr x pkgs
+          else if ignoreMissing then
+            builtins.trace "convertListToDrvs: ignoring missing derivation '${x}'" null
+          else
+            throw "convertListToDrvs: unsupported string or missing derivation: ${x}"
+        else
+          throw "convertListToDrvs: unsupported type: ${builtins.typeOf x}";
+    in
+    builtins.filter (x: x != null) (map toDrv vals);
+
+  /**
+    Converts a list of strings or derivations into a list of derivations from `pkgs`, throwing an error if any string is not found.
+
+    Arguments:
+
+    - `pkgs`: The package set to resolve string names to derivations.
+    - `vals`: A list of strings (attribute names) or derivations.
+
+    Returns:
+
+    - A list of derivations, resolving strings via `pkgs`. Throws an error if a string is missing.
+
+    @example
+    ```nix
+    lib.convertListToDrvsStrict pkgs [ pkgs.human-mj-description "human-mj-description" ]
+    ```
+
+    Type:
+      pkgs: AttrSet -> vals: [String | Derivation] -> [Derivation]
+  */
+  convertListToDrvsStrict =
+    pkgs: vals:
+    _convertListToDrvs {
+      inherit pkgs vals;
+      ignoreMissing = false;
+    };
+  /**
+    Converts a list of strings or derivations into a list of derivations from `pkgs`, skipping missing strings with a warning.
+
+    Arguments:
+
+    - `pkgs`: The package set to resolve string names to derivations.
+    - `vals`: A list of strings (attribute names) or derivations.
+
+    Returns:
+
+    - A list of derivations, resolving strings via `pkgs`. Missing strings are skipped with a warning.
+
+    @example
+    ```nix
+    lib.convertListToDrvs pkgs [ pkgs.human-mj-description "human-mj-description" ]
+    ```
+
+    Type:
+      pkgs: AttrSet -> vals: [String | Derivation] -> [Derivation]
   */
   convertListToDrvs =
     pkgs: vals:
-    map (
-      x:
-      if builtins.isAttrs x && x ? type && x.type == "derivation" then
-        x
-      else if builtins.isString x then
-        builtins.getAttr x pkgs
-      else
-        throw "convertListToDrvs: unsupported type: ${builtins.typeOf x}"
-    ) vals;
+    _convertListToDrvs {
+      inherit pkgs vals;
+      ignoreMissing = true;
+    };
 
   /**
-    Get a list of derivations from a passthru attribute (derivation or string or list of both) in a list of derivations.
+    Returns a list of derivations from a passthru attribute (which may be a derivation, a string, or a list of both) in a list of derivations.
 
     Arguments:
-      pkgs: The package set to resolve string names to derivations.
-      getField: A function that extracts the attribute from a derivation (e.g., `drv: drv.passthru.robot.module`).
-      drvs: A list of derivations containing the field.
 
-    Example:
-      lib.drvsFromPassthruField pkgs (drv: drv.passthru.robot.module) [ pkgs.human-mj-description pkgs.g1-mj-description ]
+    - `pkgs`: The package set to resolve string names to derivations.
+    - `getField`: A function that extracts the attribute from a derivation (e.g., `drv: drv.passthru.robot.module`).
+    - `drvs`: A list of derivations containing the field.
 
-    Type: pkgs: AttrSet -> getField: (Derivation -> a) -> drvs: [ Derivation ] -> [ Derivation ]
+    Returns:
+
+    - A flat list of derivations extracted from the passthru field of each input derivation.
+
+    @example
+    ```nix
+    lib.drvsFromPassthruField pkgs (drv: drv.passthru.robot.module) [
+      pkgs.human-mj-description
+      pkgs.g1-mj-description
+    ]
+    ```
+
+    Type:
+      pkgs: AttrSet -> getField: (Derivation -> a) -> drvs: [Derivation] -> [Derivation]
   */
   drvsFromPassthruField =
     pkgs: getField: drvs:
@@ -51,5 +139,75 @@ rec {
       );
     in
     convertListToDrvs pkgs names;
+
+  /**
+    mkControllerSuperbuild
+
+    Constructs a superbuild attribute set for a given controller derivation.
+
+    Arguments:
+
+    - `pkgs`: The Nixpkgs package set.
+    - `controller-drv`: The controller derivation (attribute set) to wrap.
+    - `extends` (default: `[]`): List of superbuilds to extend from.
+    - `with-suggested` (default: `true`): Whether to include suggested apps/robots.
+
+    Returns:
+
+    - extends:    The list of extended superbuilds.
+    - runtime:    Runtime environment (controllers, plugins, observers).
+    - apps:       (optional) Suggested apps, if with-suggested is true.
+    - robots:     (optional) Suggested robots, if with-suggested is true.
+    - devel:      Development environment (controllers).
+    - enabled:    The enabled controller name, if set.
+
+    Example
+
+    ```nix
+      let
+        myControllerDrv = pkgs.stdenv.mkDerivation {
+          name = "my-controller";
+          # ... build instructions ...
+          passthru = {
+            plugins = [ footsteps-planner-plugin mc-joystick-plugin ];
+            observers = [ some-observer ];
+            controller = {
+              Enabled = "ismpc_walking";
+              MainRobot = "JVRC1";
+            };
+            suggests = {
+              robots = [ "mc-hrp4" "mc-hrp2" ];
+              apps = [ "mc-mujoco" ];
+            };
+          };
+        };
+      in
+        mkControllerSuperbuild pkgs myControllerDrv { with-suggested = true; }
+    ```
+  */
+  mkControllerSuperbuild =
+    pkgs: controller-drv:
+    {
+      extends ? [ ],
+      with-suggested ? true,
+    }:
+    {
+      extends = extends;
+      runtime = {
+        controllers = [ controller-drv ];
+        plugins = convertListToDrvsStrict pkgs (controller-drv.plugins or [ ]);
+        observers = convertListToDrvsStrict pkgs (controller-drv.observers or [ ]);
+      }
+      // lib.optionalAttrs with-suggested {
+        apps = convertListToDrvs pkgs (controller-drv.suggests.apps or [ ]);
+        robots = convertListToDrvs pkgs (controller-drv.suggests.robots or [ ]);
+      };
+      devel = {
+        controllers = [ controller-drv ];
+      };
+    }
+    // lib.optionalAttrs (
+      controller-drv.controller.Enabled != null && controller-drv.controller.Enabled != ""
+    ) { enabled = controller-drv.controller.Enabled; };
 
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -69,6 +69,7 @@ rec {
     @example
     ```nix
     lib.convertListToDrvsStrict pkgs [ pkgs.human-mj-description "human-mj-description" ]
+    lib.convertListToDrvsStrict pkgs [ "mc-hrp4" ]
     ```
 
     Type:
@@ -95,6 +96,7 @@ rec {
     @example
     ```nix
     lib.convertListToDrvs pkgs [ pkgs.human-mj-description "human-mj-description" ]
+    lib.convertListToDrvs pkgs [ "mc-hrp4" ]
     ```
 
     Type:
@@ -192,20 +194,24 @@ rec {
       with-suggested ? true,
     }:
     let
-      c = controller-drv.mcRtc or { };
+      c = controller-drv.mc-rtc or { };
     in
     {
       extends = extends;
-      runtime =
-        builtins.trace "mcRtcYaml is ${c.mcRtcYaml or "not set"}" {
-          controllers = [ controller-drv ];
-          plugins = convertListToDrvsStrict pkgs (c.plugins or [ ]);
-          observers = convertListToDrvsStrict pkgs (c.observers or [ ]);
+      runtime = {
+        controllers = [ controller-drv ];
+        plugins = convertListToDrvsStrict pkgs (c.plugins or [ ]);
+        observers = convertListToDrvsStrict pkgs (c.observers or [ ]);
+      }
+      // lib.optionalAttrs with-suggested (
+        let
+          s = c.suggests or { };
+        in
+        {
+          apps = convertListToDrvs pkgs (s.apps or [ ]);
+          robots = convertListToDrvs pkgs (s.robots or [ ]);
         }
-        // lib.optionalAttrs with-suggested {
-          apps = convertListToDrvs pkgs (c.apps or [ ]);
-          robots = convertListToDrvs pkgs (c.robots or [ ]);
-        };
+      );
       devel = {
         controllers = [ controller-drv ];
       };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -195,29 +195,29 @@ rec {
     }:
     let
       c = controller-drv.mc-rtc or { };
+      s = c.suggests or { };
+      convertStrict = attr: name: convertListToDrvsStrict pkgs (attr.${name} or [ ]);
+      convertSuggested =
+        attr: name: convertListToDrvs pkgs (lib.optionals with-suggested (attr.${name} or [ ]));
     in
     {
       extends = extends;
       runtime = {
         controllers = [ controller-drv ];
-        plugins = convertListToDrvsStrict pkgs (c.plugins or [ ]);
-        observers = convertListToDrvsStrict pkgs (c.observers or [ ]);
-      }
-      // lib.optionalAttrs with-suggested (
-        let
-          s = c.suggests or { };
-        in
-        {
-          apps = convertListToDrvs pkgs (s.apps or [ ]);
-          robots = convertListToDrvs pkgs (s.robots or [ ]);
-        }
-      );
+        robots = convertStrict c "robots" ++ convertSuggested s "robots";
+        plugins = convertStrict c "plugins" ++ convertSuggested s "plugins";
+        observers = convertStrict c "observers" ++ convertSuggested s "observers";
+        apps = convertStrict c "apps" ++ convertSuggested s "apps";
+      };
       devel = {
         controllers = [ controller-drv ];
       };
     }
     // lib.optionalAttrs (c.controller.Enabled != null && c.controller.Enabled != "") {
       enabled = c.controller.Enabled;
+    }
+    // lib.optionalAttrs (c.controller.MainRobot != null && c.controller.MainRobot != "") {
+      mainRobot = c.controller.MainRobot;
     };
 
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -191,23 +191,27 @@ rec {
       extends ? [ ],
       with-suggested ? true,
     }:
+    let
+      c = controller-drv.mcRtc or { };
+    in
     {
       extends = extends;
-      runtime = {
-        controllers = [ controller-drv ];
-        plugins = convertListToDrvsStrict pkgs (controller-drv.plugins or [ ]);
-        observers = convertListToDrvsStrict pkgs (controller-drv.observers or [ ]);
-      }
-      // lib.optionalAttrs with-suggested {
-        apps = convertListToDrvs pkgs (controller-drv.suggests.apps or [ ]);
-        robots = convertListToDrvs pkgs (controller-drv.suggests.robots or [ ]);
-      };
+      runtime =
+        builtins.trace "mcRtcYaml is ${c.mcRtcYaml or "not set"}" {
+          controllers = [ controller-drv ];
+          plugins = convertListToDrvsStrict pkgs (c.plugins or [ ]);
+          observers = convertListToDrvsStrict pkgs (c.observers or [ ]);
+        }
+        // lib.optionalAttrs with-suggested {
+          apps = convertListToDrvs pkgs (c.apps or [ ]);
+          robots = convertListToDrvs pkgs (c.robots or [ ]);
+        };
       devel = {
         controllers = [ controller-drv ];
       };
     }
-    // lib.optionalAttrs (
-      controller-drv.controller.Enabled != null && controller-drv.controller.Enabled != ""
-    ) { enabled = controller-drv.controller.Enabled; };
+    // lib.optionalAttrs (c.controller.Enabled != null && c.controller.Enabled != "") {
+      enabled = c.controller.Enabled;
+    };
 
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,5 +1,42 @@
 {
   ...
 }:
-{
+rec {
+  # To test in nix repl
+  # :lf .
+  # pkgs = packages.x86_64-linux
+
+  # Converts a list of strings or derivations into a list of derivations in pkgs
+  #
+  # Test with
+  # lib.convertListToDrvs pkgs [ pkgs.human-mj-description "human-mj-description"]
+  convertListToDrvs =
+    pkgs: vals:
+    map (
+      x:
+      if builtins.isAttrs x && x ? type && x.type == "derivation" then
+        x
+      else if builtins.isString x then
+        builtins.getAttr x pkgs
+      else
+        throw "convertListToDrvs: unsupported type: ${builtins.typeOf x}"
+    ) vals;
+
+  # Get a list of derivations from a passthru attribute (derivation or string or list of both) in a list of derivations
+  # Args:
+  # - pkgs
+  # - getField: a function returning the attribute ex: (drv: drv.passthru.robot.module)
+  # - drvs: a list of derivations containing the field
+  #
+  # Test with
+  # lib.drvsFromPassthruField pkgs (drv: drv.passthru.robot.module) [ pkgs.human-mj-description pkgs.g1-mj-description ]
+  drvsFromPassthruField =
+    pkgs: getField: drvs:
+    let
+      names = builtins.concatMap (field: if builtins.isList field then field else [ field ]) (
+        map getField drvs
+      );
+    in
+    convertListToDrvs pkgs names;
+
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -6,10 +6,18 @@ rec {
   # :lf .
   # pkgs = packages.x86_64-linux
 
-  # Converts a list of strings or derivations into a list of derivations in pkgs
-  #
-  # Test with
-  # lib.convertListToDrvs pkgs [ pkgs.human-mj-description "human-mj-description"]
+  /**
+    Converts a list of strings or derivations into a list of derivations from pkgs.
+
+    Arguments:
+      pkgs: The package set to resolve string names to derivations.
+      vals: A list of strings (attribute names) or derivations.
+
+    Example:
+      lib.convertListToDrvs pkgs [ pkgs.human-mj-description "human-mj-description" ]
+
+    Type: pkgs: AttrSet -> vals: [ String | Derivation ] -> [ Derivation ]
+  */
   convertListToDrvs =
     pkgs: vals:
     map (
@@ -22,14 +30,19 @@ rec {
         throw "convertListToDrvs: unsupported type: ${builtins.typeOf x}"
     ) vals;
 
-  # Get a list of derivations from a passthru attribute (derivation or string or list of both) in a list of derivations
-  # Args:
-  # - pkgs
-  # - getField: a function returning the attribute ex: (drv: drv.passthru.robot.module)
-  # - drvs: a list of derivations containing the field
-  #
-  # Test with
-  # lib.drvsFromPassthruField pkgs (drv: drv.passthru.robot.module) [ pkgs.human-mj-description pkgs.g1-mj-description ]
+  /**
+    Get a list of derivations from a passthru attribute (derivation or string or list of both) in a list of derivations.
+
+    Arguments:
+      pkgs: The package set to resolve string names to derivations.
+      getField: A function that extracts the attribute from a derivation (e.g., `drv: drv.passthru.robot.module`).
+      drvs: A list of derivations containing the field.
+
+    Example:
+      lib.drvsFromPassthruField pkgs (drv: drv.passthru.robot.module) [ pkgs.human-mj-description pkgs.g1-mj-description ]
+
+    Type: pkgs: AttrSet -> getField: (Derivation -> a) -> drvs: [ Derivation ] -> [ Derivation ]
+  */
   drvsFromPassthruField =
     pkgs: getField: drvs:
     let

--- a/module.nix
+++ b/module.nix
@@ -228,6 +228,7 @@ in
           };
 
           # auto-generated configs from controller's passthru.mc-rtc
+          ismpc-walking = mc-rtc-lib.mkControllerSuperbuild pkgs pkgs.ismpc-walking-controller { };
           lipm-walking = mc-rtc-lib.mkControllerSuperbuild pkgs pkgs.lipm-walking-controller { };
           robogami = mc-rtc-lib.mkControllerSuperbuild pkgs pkgs.robogami-controller { };
 

--- a/module.nix
+++ b/module.nix
@@ -83,7 +83,9 @@ in
 
     overlays = {
       private = lib.mkEnableOption "enables the private repository overlay";
-      ccache = lib.mkEnableOption "enables the ccache overlay";
+      ccache = lib.mkEnableOption "enables the ccache overlay" // {
+        default = true;
+      };
     };
 
     gepetto = {

--- a/module.nix
+++ b/module.nix
@@ -5,6 +5,7 @@
   flakoboros,
   jrl-cmakemodulesv2,
   make-shell,
+  mc-rtc-lib,
   ...
 }: # localFlake
 
@@ -41,6 +42,7 @@ let
       stdenv = prev.stdenv;
       with-ros = cfg.with-ros;
       with-python = cfg.with-python;
+      inherit mc-rtc-lib;
       inherit qt;
     })
       final
@@ -68,7 +70,7 @@ let
     with-private = cfg.overlays.private;
   };
 
-  superbuildFlakeModule = ./modules/superbuild/superbuild.nix;
+  superbuildFlakeModule = import ./modules/superbuild/superbuild.nix { inherit mc-rtc-lib; };
 in
 {
   options.mc-rtc-nix = {

--- a/module.nix
+++ b/module.nix
@@ -227,31 +227,9 @@ in
             };
           };
 
-          lipm-walking = with pkgs; {
-            extends = [ "default" ];
-            enabled = "LIPMWalking";
-            runtime = {
-              observers = [ mc-state-observation ];
-              apps = maybe-mc-mujoco mc-mujoco;
-            };
-            devel = {
-              controllers = [ lipm-walking-controller ];
-            };
-          };
-
-          robogami = with pkgs; {
-            extends = [ "default" ];
-            mainRobot = "robogami";
-            enabled = "RobogamiController";
-            runtime = {
-              robots = [
-                mc-robogami
-              ];
-            };
-            devel = {
-              controllers = [ robogami-controller ];
-            };
-          };
+          # auto-generated configs from controller's passthru.mc-rtc
+          lipm-walking = mc-rtc-lib.mkControllerSuperbuild pkgs pkgs.lipm-walking-controller { };
+          robogami = mc-rtc-lib.mkControllerSuperbuild pkgs pkgs.robogami-controller { };
 
           panda-prosthesis = with pkgs; {
             extends = [ "minimal" ];

--- a/module.nix
+++ b/module.nix
@@ -63,7 +63,10 @@ let
     jrl-cmakemodulesv2 = jrl-cmakemodulesv2.packages.${prev.system}.default;
   };
 
-  mcRtcCcacheOverlay = import ./overlay-ccache.nix { };
+  mcRtcCcacheOverlay = import ./overlay-ccache.nix {
+    inherit lib;
+    with-private = cfg.overlays.private;
+  };
 
   superbuildFlakeModule = ./modules/superbuild/superbuild.nix;
 in

--- a/module.nix
+++ b/module.nix
@@ -183,7 +183,7 @@ in
               apps = [
                 pkgs.mc-rtc-magnum
               ]
-              ++ lib.optionals (cfg.with-ros || superbuildCfg.withRos) [ pkgs.mc-rtc-ticker ];
+              ++ lib.optionals (cfg.with-ros || superbuildCfg.withRos) [ pkgs.mc-rtc-rviz ];
             };
           };
 
@@ -375,6 +375,7 @@ in
 
                 # Main GUIs and applications
                 inherit (pkgs)
+                  mc-rtc-ticker
                   mc-rtc-magnum
                   ;
 
@@ -429,7 +430,7 @@ in
                 inherit (pkgs) mc-robot-tools sphinx-cmake;
               }
               (lib.optionalAttrs (cfg.with-ros || superbuildCfg.withRos) {
-                inherit (pkgs) mc-rtc-ticker;
+                inherit (pkgs) mc-rtc-rviz;
               })
               (lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isDarwin) {
                 inherit (pkgs) mc-udp mc-mujoco mc-mujoco-full;

--- a/modules/superbuild/resolver.nix
+++ b/modules/superbuild/resolver.nix
@@ -28,13 +28,13 @@ let
   preferNumber = previous: next: if next != null then next else previous;
 
   mergeComponent = left: right: {
-    apps = left.apps ++ right.apps;
-    robots = left.robots ++ right.robots;
-    controllers = left.controllers ++ right.controllers;
-    observers = left.observers ++ right.observers;
-    plugins = left.plugins ++ right.plugins;
+    apps = lib.unique (left.apps ++ right.apps);
+    robots = lib.unique (left.robots ++ right.robots);
+    controllers = lib.unique (left.controllers ++ right.controllers);
+    observers = lib.unique (left.observers ++ right.observers);
+    plugins = lib.unique (left.plugins ++ right.plugins);
     config = preferString left.config right.config;
-    extraConfigFiles = left.extraConfigFiles ++ right.extraConfigFiles;
+    extraConfigFiles = lib.unique (left.extraConfigFiles ++ right.extraConfigFiles);
   };
 
   mergeRuntime = mergeComponent;

--- a/modules/superbuild/superbuild.nix
+++ b/modules/superbuild/superbuild.nix
@@ -79,6 +79,32 @@ let
 
   title = "  ${pname} interactive shell" + lib.optionalString isDevel " (devel)" + "  ";
   line = lib.concatStrings (builtins.genList (_: "=") (builtins.stringLength title));
+
+  # Prepare devPrefix and shell* variables for use in mcRtcYaml
+  devPrefix = lib.optional isDevel localInstallPath;
+  shellControllers = devPrefix ++ activeRuntime.controllers;
+  shellRobots = devPrefix ++ activeRuntime.robots;
+  shellObservers = devPrefix ++ activeRuntime.observers;
+  shellPlugins = devPrefix ++ activeRuntime.plugins;
+
+  mcRtcYaml = pkgs.writeText "mc_rtc.yaml" ''
+    ---
+    ${lib.optionalString (mainRobot != null && mainRobot != "") "MainRobot: \"${mainRobot}\""}
+    ${lib.optionalString (enabled != null && enabled != "") "Enabled: \"${enabled}\""}
+    ${lib.optionalString (timeStep != null) "Timestep: ${toString timeStep}"}
+    ControllerModulePaths: [${mkModulePaths "mc_controller" shellControllers}]
+    RobotModulePaths: [${mkModulePaths "mc_robots" shellRobots}]
+    ObserverModulePaths: [${mkModulePaths "mc_observers" shellObservers}]
+    GlobalPluginPaths: [${mkModulePaths "mc_plugins" shellPlugins}]
+    LoadUserConfiguration: false
+  '';
+
+  shellConfigs = [
+    mcRtcYaml
+  ]
+  ++ lib.optional (activeConfigPath != null) activeConfigPath
+  ++ extraConfigPaths;
+
 in
 {
   options.mc-rtc-superbuild = import ./options.nix { inherit lib; };
@@ -122,18 +148,6 @@ in
 
     shellHook =
       let
-        devPrefix = lib.optional isDevel localInstallPath;
-        shellControllers = devPrefix ++ activeRuntime.controllers;
-        shellRobots = devPrefix ++ activeRuntime.robots;
-        shellObservers = devPrefix ++ activeRuntime.observers;
-        shellPlugins = devPrefix ++ activeRuntime.plugins;
-
-        shellConfigs = [
-          "${localPath}/mc_rtc.yaml"
-        ]
-        ++ lib.optional (activeConfigPath != null) activeConfigPath
-        ++ extraConfigPaths;
-
         printRuntimeDeps =
           showPaths: listGroup:
           let
@@ -168,18 +182,6 @@ in
         export PROJECT_DIR="$(pwd)/${relativeLocalPath}"
         export INSTALL_DIR="$PROJECT_DIR/install"
         mkdir -p $INSTALL_DIR
-
-        cat <<EOF_CONF > $PROJECT_DIR/mc_rtc.yaml
-        ---
-        ${lib.optionalString (mainRobot != null && mainRobot != "") "MainRobot: \"${mainRobot}\""}
-        ${lib.optionalString (enabled != null && enabled != "") "Enabled: \"${enabled}\""}
-        ${lib.optionalString (timeStep != null) "Timestep: ${toString timeStep}"}
-        ControllerModulePaths: [${mkModulePaths "mc_controller" shellControllers}]
-        RobotModulePaths: [${mkModulePaths "mc_robots" shellRobots}]
-        ObserverModulePaths: [${mkModulePaths "mc_observers" shellObservers}]
-        GlobalPluginPaths: [${mkModulePaths "mc_plugins" shellPlugins}]
-        LoadUserConfiguration: false
-        EOF_CONF
 
         export MC_RTC_PATH=${pkgs.mc-rtc}
         export MC_RTC_JEKYLL_PLUGINS=${pkgs.mc-rtc}/share/doc/mc-rtc/jekyll/plugins

--- a/modules/superbuild/superbuild.nix
+++ b/modules/superbuild/superbuild.nix
@@ -106,39 +106,68 @@ let
   ++ lib.optional (activeConfigPath != null) activeConfigPath
   ++ extraConfigPaths;
 
-  # Generate a runAllAppsScript for each controller
-  runAllAppsScripts = lib.listToAttrs (
-    map (
-      controller:
-      let
-        name = controller.pname or controller.name or "controller";
-        apps = mc-rtc-lib.convertListToDrvs pkgs (controller.mc-rtc.runApps or [ ]);
-        appPaths = lib.forEach apps (
-          app:
-          if lib.isDerivation app && app ? meta && app.meta ? mainProgram then
-            "${app}/bin/${app.meta.mainProgram}"
-          else
-            null
-        );
-        filteredAppPaths = lib.filter (x: x != null) appPaths;
-        scriptBin = pkgs.writeShellScriptBin "run-${name}" ''
-          set -e
-          pids=""
-          trap 'echo "Stopping apps..."; [ -n "$pids" ] && kill -9 $pids 2>/dev/null || true; exit' INT
-          ${lib.concatMapStringsSep "\n" (appPath: ''
-            echo "Starting ${appPath}"
-            "${appPath}" &
-            pids="$pids $!"
-          '') filteredAppPaths}
-          wait
-        '';
-      in
+  /**
+    `runAllAppsScripts`
+
+    Attribute set mapping controller names to shell script derivations that launch all associated apps for each controller.
+
+    Only includes controllers where `isController = true` and `mc-rtc.runApps` is non-empty.
+
+    Example output:
       {
-        inherit name;
-        value = scriptBin;
+        controller1 = <derivation /nix/store/...-run-controller1>;
+        controller2 = <derivation /nix/store/...-run-controller2>;
       }
-    ) (lib.filter (c: (c.mc-rtc.runApps or [ ]) != [ ]) activeRuntime.controllers)
-  );
+
+    Each script:
+      - Starts all apps listed in `mc-rtc.runApps` for the controller.
+      - Runs each app in the background and waits for all to finish.
+      - Handles SIGINT (Ctrl+C) to kill all started apps.
+
+    If no controllers match, the result is an empty attribute set: `{}`.
+  */
+  runAllAppsScripts =
+    let
+      res = lib.listToAttrs (
+        map
+          (
+            controller:
+            let
+              name = controller.pname or controller.name or "controller";
+              apps = mc-rtc-lib.convertListToDrvs pkgs (controller.mc-rtc.runApps or [ ]);
+              appPaths = lib.forEach apps (
+                app:
+                if lib.isDerivation app && app ? meta && app.meta ? mainProgram then
+                  "${app}/bin/${app.meta.mainProgram}"
+                else
+                  null
+              );
+              filteredAppPaths = lib.filter (x: x != null) appPaths;
+              scriptBin = pkgs.writeShellScriptBin "run-${name}" ''
+                set -e
+                pids=""
+                trap 'echo "Stopping apps..."; [ -n "$pids" ] && kill -9 $pids 2>/dev/null || true; exit' INT
+                ${lib.concatMapStringsSep "\n" (appPath: ''
+                  echo "Starting ${appPath}"
+                  "${appPath}" &
+                  pids="$pids $!"
+                '') filteredAppPaths}
+                wait
+              '';
+            in
+            {
+              inherit name;
+              value = scriptBin;
+            }
+          )
+          (
+            lib.filter (
+              c: (c.mc-rtc.runApps or [ ]) != [ ] && (c.mc-rtc.isController or false)
+            ) activeRuntime.controllers
+          )
+      );
+    in
+    builtins.trace (builtins.toJSON res) res;
 
 in
 {
@@ -259,12 +288,14 @@ in
         echo -e "mc_rtc will use the following configuration files MC_RTC_CONTROLLER_CONFIG=$MC_RTC_CONTROLLER_CONFIG\n"
         echo "You can list more convenience environment variables with $ mc_rtc_env"
         alias mc_rtc_env="env | grep '^MC_RTC_'"
-        echo "You can run the default apps for this controllers with:"
-        ls ${
-          lib.concatStringsSep " " (
-            map (c: "${runAllAppsScripts.${c.pname or c.name or "controller"}}/bin") activeRuntime.controllers
-          )
-        }
+        ${lib.optionalString (runAllAppsScripts != { }) ''
+          echo "You can run the default apps for these controllers with:"
+          ls ${
+            lib.concatStringsSep " " (
+              map (name: "${runAllAppsScripts.${name}}/bin") (builtins.attrNames runAllAppsScripts)
+            )
+          }
+        ''}
         echo ""
         echo "--------"
       '';

--- a/modules/superbuild/superbuild.nix
+++ b/modules/superbuild/superbuild.nix
@@ -1,3 +1,4 @@
+{ mc-rtc-lib }:
 {
   lib,
   pkgs,
@@ -105,6 +106,40 @@ let
   ++ lib.optional (activeConfigPath != null) activeConfigPath
   ++ extraConfigPaths;
 
+  # Generate a runAllAppsScript for each controller
+  runAllAppsScripts = lib.listToAttrs (
+    map (
+      controller:
+      let
+        name = controller.pname or controller.name or "controller";
+        apps = mc-rtc-lib.convertListToDrvs pkgs (controller.mc-rtc.runApps or [ ]);
+        appPaths = lib.forEach apps (
+          app:
+          if lib.isDerivation app && app ? meta && app.meta ? mainProgram then
+            "${app}/bin/${app.meta.mainProgram}"
+          else
+            null
+        );
+        filteredAppPaths = lib.filter (x: x != null) appPaths;
+        scriptBin = pkgs.writeShellScriptBin "run-${name}" ''
+          set -e
+          pids=""
+          trap 'echo "Stopping apps..."; [ -n "$pids" ] && kill -9 $pids 2>/dev/null || true; exit' INT
+          ${lib.concatMapStringsSep "\n" (appPath: ''
+            echo "Starting ${appPath}"
+            "${appPath}" &
+            pids="$pids $!"
+          '') filteredAppPaths}
+          wait
+        '';
+      in
+      {
+        inherit name;
+        value = scriptBin;
+      }
+    ) (lib.filter (c: (c.mc-rtc.runApps or [ ]) != [ ]) activeRuntime.controllers)
+  );
+
 in
 {
   options.mc-rtc-superbuild = import ./options.nix { inherit lib; };
@@ -126,6 +161,7 @@ in
         gdb
         mc-rtc
       ]
+      ++ (lib.attrValues runAllAppsScripts)
       ++ traceGroup "apps" activeRuntime.apps
       ++ traceGroup "robots" activeRuntime.robots
       ++ traceGroup "plugins" activeRuntime.plugins
@@ -225,6 +261,17 @@ in
 
         echo -e "mc_rtc will use the following configuration files $MC_RTC_CONTROLLER_CONFIG\n"
         echo "--------"
+
+
+        # Add run_<controller> shell functions for each controller
+        echo "Added run-<controller> scripts to your PATH:"
+        ls ${
+          lib.concatStringsSep " " (
+            map (c: "${runAllAppsScripts.${c.pname or c.name or "controller"}}/bin") activeRuntime.controllers
+          )
+        }
+
+          echo "Added run_<controller> shell functions for each controller."
       '';
   };
 }

--- a/modules/superbuild/superbuild.nix
+++ b/modules/superbuild/superbuild.nix
@@ -255,23 +255,18 @@ in
         ''}
 
         echo ""
-        echo "The following convenience environment variables are set:"
-        env | grep '^MC_RTC_'
-        echo ""
 
-        echo -e "mc_rtc will use the following configuration files $MC_RTC_CONTROLLER_CONFIG\n"
-        echo "--------"
-
-
-        # Add run_<controller> shell functions for each controller
-        echo "Added run-<controller> scripts to your PATH:"
+        echo -e "mc_rtc will use the following configuration files MC_RTC_CONTROLLER_CONFIG=$MC_RTC_CONTROLLER_CONFIG\n"
+        echo "You can list more convenience environment variables with $ mc_rtc_env"
+        alias mc_rtc_env="env | grep '^MC_RTC_'"
+        echo "You can run the default apps for this controllers with:"
         ls ${
           lib.concatStringsSep " " (
             map (c: "${runAllAppsScripts.${c.pname or c.name or "controller"}}/bin") activeRuntime.controllers
           )
         }
-
-          echo "Added run_<controller> shell functions for each controller."
+        echo ""
+        echo "--------"
       '';
   };
 }

--- a/overlay-ccache.nix
+++ b/overlay-ccache.nix
@@ -26,8 +26,9 @@ let
   skipCcahePackages = [
     "mc-rtc-msgs"
     "magnum-with-plugins"
-    "mc-rtc-ticker"
+    "mc-rtc-rviz"
     "mc-rtc-rviz-panel"
+    "mc-rtc-ticker"
     "mc-mujoco-robots-public"
     "mc-mujoco-robots-private"
     "mc-mujoco-robots"
@@ -87,7 +88,6 @@ let
     "mc-rtc-ros-compat"
     "mc-rtc-python-utils"
     "mc-rtc-rviz-panel"
-    "mc-rtc-ticker"
     "gram-savitzky-golay"
     "mujoco"
     "jvrc1-mj-description"

--- a/overlay-ccache.nix
+++ b/overlay-ccache.nix
@@ -1,4 +1,7 @@
-{ }:
+{
+  lib,
+  with-private ? false,
+}:
 
 _final: prev:
 let
@@ -9,8 +12,12 @@ let
       map (name: {
         inherit name;
         value =
-          # builtins.trace "overriding stdenv with ccacheStdenv for package ${name}"
-          (getAttr name prev).override { stdenv = prev.ccacheStdenv; };
+          if hasAttr name prev && (getAttr name prev) ? override then
+            (getAttr name prev).override { stdenv = prev.ccacheStdenv; }
+          else if hasAttr name prev then
+            getAttr name prev
+          else
+            trace "withCCache: package '${name}' missing in overlay, skipping" null;
       }) packages
     );
   # usually this mean they don't have stdenv as an agument
@@ -51,7 +58,7 @@ let
     "pendulum-feasibility-solver"
     "footsteps-planner-plugin"
     "mc-joystick-plugin"
-    "ismpc-walking-controller"
+    # "ismpc-walking-controller" already handed by mkMcRtcController
     "robogami-controller"
     "mc-udp"
     "franka-description"
@@ -133,7 +140,7 @@ let
     "mc-mujoco-robots-private"
     "mc-mujoco-full"
   ];
-  allPackages = allPublicPackages ++ allPivatePackages;
+  allPackages = allPublicPackages ++ (lib.optionals with-private allPivatePackages);
   ccachePackages = builtins.filter (name: !(builtins.elem name skipCcahePackages)) allPackages;
 in
 {

--- a/overlay-ccache.nix
+++ b/overlay-ccache.nix
@@ -33,6 +33,10 @@ let
     "mc-mujoco-robots-private"
     "mc-mujoco-robots"
     "ur-description"
+    # already handed by mkMcRtcController
+    "ismpc-walking-controller"
+    "robogami-controller"
+    "lipm-walking-controller"
   ];
   allPublicPackages = [
     "nanomsg"
@@ -55,12 +59,9 @@ let
     "openrtm-aist"
     "openrtm-aist-python"
     "mc-state-observation"
-    "lipm-walking-controller"
     "pendulum-feasibility-solver"
     "footsteps-planner-plugin"
     "mc-joystick-plugin"
-    # "ismpc-walking-controller" already handed by mkMcRtcController
-    "robogami-controller"
     "mc-udp"
     "franka-description"
     "g1-description"

--- a/overlay-ccache.nix
+++ b/overlay-ccache.nix
@@ -9,9 +9,8 @@ let
       map (name: {
         inherit name;
         value =
-          builtins.trace "overriding stdenv with ccacheStdenv for package ${name}"
-            (getAttr name prev).override
-            { stdenv = prev.ccacheStdenv; };
+          # builtins.trace "overriding stdenv with ccacheStdenv for package ${name}"
+          (getAttr name prev).override { stdenv = prev.ccacheStdenv; };
       }) packages
     );
   # usually this mean they don't have stdenv as an agument

--- a/overlay-ccache.nix
+++ b/overlay-ccache.nix
@@ -171,5 +171,8 @@ in
     '';
   };
 }
-// withCCache [ "buildRosPackage" ]
+// withCCache [
+  "buildRosPackage"
+  "mkMcRtcController"
+]
 // withCCache ccachePackages

--- a/overlay.nix
+++ b/overlay.nix
@@ -41,11 +41,7 @@
       xacro
       ;
 
-    mkMcRtcController = import ./pkgs/mc-rtc/mk-mc-rtc-controller.nix {
-      inherit lib;
-      pkgs = final.pkgs;
-      stdenv = final.pkgs.stdenv;
-    };
+    mkMcRtcController = final.callPackage ./pkgs/mc-rtc/mk-mc-rtc-controller.nix { };
 
     nanomsg = prev.nanomsg.overrideAttrs (_old: rec {
       postPatch = ''

--- a/overlay.nix
+++ b/overlay.nix
@@ -41,6 +41,12 @@
       xacro
       ;
 
+    mkMcRtcController = import ./pkgs/mc-rtc/mk-mc-rtc-controller.nix {
+      inherit lib;
+      pkgs = final.pkgs;
+      stdenv = final.pkgs.stdenv;
+    };
+
     nanomsg = prev.nanomsg.overrideAttrs (_old: rec {
       postPatch = ''
         substituteInPlace cmake/nanomsg-config.cmake.in \

--- a/overlay.nix
+++ b/overlay.nix
@@ -18,6 +18,7 @@
     callWithRos = pkg: args: final.callPackage pkg (args // { inherit with-ros; });
   in
   {
+    # FIXME ros version
     inherit (prev.rosPackages.jazzy)
       buildRosPackage
       ament-cmake
@@ -140,16 +141,11 @@
       jrl-cmakemodules = final.jrl-cmakemodulesv2;
     };
     mc-rtc-python-utils = final.callPackage ./pkgs/mc-rtc/mc-rtc-python-utils.nix { };
-    #mc-rtc = callWithRos ./pkgs/mc-rtc/mc-rtc.nix {};
-    # mc-rtc-rviz-panel = prev.libsForQt5.callPackage ./pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix { inherit useLocal; inherit localWorkspace; };
     mc-rtc-rviz-panel = prev.libsForQt5.callPackage ./pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix {
       inherit qt;
     };
-    # mc-rtc-ticker = final.callPackage ./pkgs/mc-rtc/ros/mc-rtc-ticker.nix {};
-    mc-rtc-ticker = final.callPackage ./pkgs/mc-rtc/ros/mc-rtc-ticker.nix { };
-    # mc-rtc = final.callPackage ./pkgs/mc-rtc/mc-rtc.nix { with-ros = true; };
-    # mc-rtc = final.callPackage ./pkgs/mc-rtc/mc-rtc.nix { };
-    # mc-rtc-magnum = final.callPackage ./pkgs/mc-rtc-magnum {};
+    mc-rtc-rviz = final.callPackage ./pkgs/mc-rtc/ros/mc-rtc-rviz.nix { };
+    mc-rtc-ticker = final.callPackage ./pkgs/mc-rtc/mc-rtc-ticker.nix { };
     gram-savitzky-golay = final.callPackage ./pkgs/gram-savitzky-golay { };
 
     ##########

--- a/pkgs/mc-rtc-magnum/default.nix
+++ b/pkgs/mc-rtc-magnum/default.nix
@@ -50,6 +50,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Magnum-based standalone viewer for mc-rtc";
     homepage = "https://github.com/mc-rtc/mc_rtc-magnum";
+    mainProgram = "mc-rtc-magnum";
     license = licenses.bsd2;
     maintainers = [ ];
     platforms = platforms.all;

--- a/pkgs/mc-rtc-magnum/standalone.nix
+++ b/pkgs/mc-rtc-magnum/standalone.nix
@@ -71,5 +71,6 @@ stdenv.mkDerivation {
     license = licenses.bsd2;
     maintainers = [ ];
     platforms = platforms.all;
+    mainProgram = "mc-rtc-magnum";
   };
 }

--- a/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
+++ b/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   mkMcRtcController,
   lib,
   fetchFromGitHub,
@@ -56,8 +57,17 @@ mkMcRtcController {
         # FIXME(mc-rhps1): too large for now
         # "mc-rhps1"
       ];
-      apps = [ "mc-mujoco" ];
+      apps = [
+        "mc-rtc-ticker"
+        "mc-rtc-magnum"
+      ]
+      ++ lib.optional (!stdenv.hostPlatform.isDarwin) "mc-mujoco";
     };
-    runApps = [ "mc-mujoco" ];
+    runApps =
+      lib.optional (!stdenv.hostPlatform.isDarwin) "mc-mujoco"
+      ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
+        "mc-rtc-ticker"
+        "mc-rtc-magnum"
+      ];
   };
 }

--- a/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
+++ b/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
@@ -1,5 +1,5 @@
 {
-  stdenv,
+  mkMcRtcController,
   lib,
   fetchFromGitHub,
   cmake,
@@ -10,17 +10,15 @@
   mc-joystick-plugin,
 }:
 
-stdenv.mkDerivation rec {
+mkMcRtcController {
   pname = "ismpc-walking-controller";
   version = "0.1.0";
-
   src = fetchFromGitHub {
     owner = "jrl-umi3218";
     repo = "lipm_walking_controller";
-    tag = "v${version}";
+    tag = "v0.1.0";
     hash = "sha256-tPWzbxuJbJm5zlUzU8jQJSdTIOsW8mb/Ci2DOeFdr4M=";
   };
-
   buildInputs = [ jrl-cmakemodulesv2 ];
   nativeBuildInputs = [ cmake ];
   propagatedBuildInputs = [
@@ -28,9 +26,18 @@ stdenv.mkDerivation rec {
     pendulum-feasibility-solver
     mc-joystick-plugin
   ];
-
-  # XXX(mc-rtc-passthru)
-  passthru = {
+  cmakeFlags = [
+    "-DINSTALL_DOCUMENTATION=OFF"
+    "-DMC_RTC_HONOR_INSTALL_PREFIX=ON"
+  ];
+  doCheck = true;
+  meta = with lib; {
+    description = "Walking controller based on linear inverted pendulum tracking";
+    homepage = "https://github.com/isri-aist/ismpc_walking";
+    license = licenses.bsd2;
+    platforms = platforms.all;
+  };
+  mcRtc = {
     plugins = [
       footsteps-planner-plugin
       mc-joystick-plugin
@@ -50,19 +57,5 @@ stdenv.mkDerivation rec {
       ];
       apps = [ "mc-mujoco" ];
     };
-  };
-
-  cmakeFlags = [
-    "-DINSTALL_DOCUMENTATION=OFF"
-    "-DMC_RTC_HONOR_INSTALL_PREFIX=ON"
-  ];
-
-  doCheck = true;
-
-  meta = with lib; {
-    description = "Walking controller based on linear inverted pendulum tracking";
-    homepage = "https://github.com/isri-aist/ismpc_walking";
-    license = licenses.bsd2;
-    platforms = platforms.all;
   };
 }

--- a/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
+++ b/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
@@ -14,10 +14,10 @@ mkMcRtcController {
   pname = "ismpc-walking-controller";
   version = "0.1.0";
   src = fetchFromGitHub {
-    owner = "jrl-umi3218";
-    repo = "lipm_walking_controller";
-    tag = "v0.1.0";
-    hash = "sha256-tPWzbxuJbJm5zlUzU8jQJSdTIOsW8mb/Ci2DOeFdr4M=";
+    owner = "isri-aist";
+    repo = "ismpc_walking";
+    rev = "6cb5dfc280265fe06068accac79227fdc7bed39c";
+    hash = "sha256-4m7o/ujtHKbonxmV57QvZ7IY4lDQVP1dBSosbZlB92Y=";
   };
   buildInputs = [ jrl-cmakemodulesv2 ];
   nativeBuildInputs = [ cmake ];

--- a/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
+++ b/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
@@ -37,7 +37,7 @@ mkMcRtcController {
     license = licenses.bsd2;
     platforms = platforms.all;
   };
-  mcRtc = {
+  passthru.mc-rtc = {
     plugins = [
       footsteps-planner-plugin
       mc-joystick-plugin
@@ -57,5 +57,6 @@ mkMcRtcController {
       ];
       apps = [ "mc-mujoco" ];
     };
+    runApps = [ "mc-mujoco" ];
   };
 }

--- a/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
+++ b/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   # XXX(mc-rtc-passthru)
   passthru = {
-    mc-rtc.plugins = [
+    plugins = [
       footsteps-planner-plugin
       mc-joystick-plugin
     ];

--- a/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
+++ b/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
@@ -52,8 +52,9 @@ mkMcRtcController {
         "mc-hrp4"
         "mc-hrp2"
         "mc-hrp5-p"
-        "mc-rhps1"
         "mc-hrp4cr"
+        # FIXME(mc-rhps1): too large for now
+        # "mc-rhps1"
       ];
       apps = [ "mc-mujoco" ];
     };

--- a/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
+++ b/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
@@ -35,6 +35,20 @@ stdenv.mkDerivation rec {
       footsteps-planner-plugin
       mc-joystick-plugin
     ];
+    controller = {
+      Enabled = "ismpc_walking";
+      MainRobot = "JVRC1";
+    };
+    suggests = {
+      robots = [
+        "mc-hrp4"
+        "mc-hrp2"
+        "mc-hrp5-p"
+        "mc-rhps1"
+        "mc-hrp4cr"
+      ];
+      apps = [ "mc-mujoco" ];
+    };
   };
 
   cmakeFlags = [

--- a/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
+++ b/pkgs/mc-rtc/controllers/ismpc-walking/ismpc-walking-controller.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
       footsteps-planner-plugin
       mc-joystick-plugin
     ];
+    observers = [ "mc-state-observation" ];
     controller = {
       Enabled = "ismpc_walking";
       MainRobot = "JVRC1";

--- a/pkgs/mc-rtc/controllers/lipm-walking-controller/default.nix
+++ b/pkgs/mc-rtc/controllers/lipm-walking-controller/default.nix
@@ -1,5 +1,5 @@
 {
-  stdenv,
+  mkMcRtcController,
   lib,
   fetchFromGitHub,
   cmake,
@@ -7,7 +7,7 @@
   copra,
 }:
 
-stdenv.mkDerivation rec {
+mkMcRtcController rec {
   pname = "lipm-walking-controller";
   version = "1.7.1";
 
@@ -30,6 +30,29 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = true;
+
+  passthru.mc-rtc = {
+    plugins = [ ]; # todo add external footstep planner plugins
+    observers = [ "mc-state-observation" ];
+    controller = {
+      Enabled = "LIPMWalking";
+      MainRobot = "JVRC1";
+    };
+    suggests = {
+      robots = [
+        "mc-hrp4"
+        "mc-hrp2"
+        "mc-hrp5-p"
+        "mc-rhps1"
+        "mc-hrp4cr"
+      ];
+      apps = [
+        "mc-mujoco"
+        "mc-rtc-magnum"
+      ];
+    };
+    runApps = [ "mc-mujoco" ];
+  };
 
   meta = with lib; {
     description = "Walking controller based on linear inverted pendulum tracking";

--- a/pkgs/mc-rtc/controllers/lipm-walking-controller/default.nix
+++ b/pkgs/mc-rtc/controllers/lipm-walking-controller/default.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   mkMcRtcController,
   lib,
   fetchFromGitHub,
@@ -48,11 +49,17 @@ mkMcRtcController rec {
         # "mc-rhps1"
       ];
       apps = [
-        "mc-mujoco"
+        "mc-rtc-ticker"
+        "mc-rtc-magnum"
+      ]
+      ++ lib.optional (!stdenv.hostPlatform.isDarwin) "mc-mujoco";
+    };
+    runApps =
+      lib.optional (!stdenv.hostPlatform.isDarwin) "mc-mujoco"
+      ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
+        "mc-rtc-ticker"
         "mc-rtc-magnum"
       ];
-    };
-    runApps = [ "mc-mujoco" ];
   };
 
   meta = with lib; {

--- a/pkgs/mc-rtc/controllers/lipm-walking-controller/default.nix
+++ b/pkgs/mc-rtc/controllers/lipm-walking-controller/default.nix
@@ -43,8 +43,9 @@ mkMcRtcController rec {
         "mc-hrp4"
         "mc-hrp2"
         "mc-hrp5-p"
-        "mc-rhps1"
         "mc-hrp4cr"
+        # FIXME(mc-rhps1): too large for now
+        # "mc-rhps1"
       ];
       apps = [
         "mc-mujoco"

--- a/pkgs/mc-rtc/controllers/robogami-controller/default.nix
+++ b/pkgs/mc-rtc/controllers/robogami-controller/default.nix
@@ -1,12 +1,12 @@
 {
-  stdenv,
+  mkMcRtcController,
   lib,
   fetchFromGitHub,
   cmake,
   mc-rtc,
 }:
 
-stdenv.mkDerivation {
+mkMcRtcController {
   pname = "robogami-controller";
   version = "0.0.0";
 
@@ -28,6 +28,21 @@ stdenv.mkDerivation {
   ];
 
   doCheck = false;
+
+  passthru.mc-rtc = {
+    plugins = [ ];
+    observers = [ ];
+    controller = {
+      Enabled = "RobogamiController";
+      MainRobot = "robogami";
+    };
+    robots = [ "mc-robogami" ];
+    apps = [ "mc-rtc-magnum" ];
+    runApps = [
+      "mc-rtc-ticker"
+      "mc-rtc-magnum"
+    ];
+  };
 
   meta = with lib; {
     description = "Single Robogami module mc_rtc FSM controller";

--- a/pkgs/mc-rtc/mc-mujoco/robots/g1-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/g1-mj-description.nix
@@ -16,3 +16,10 @@ import ./mj-description-base.nix {
   repo = "g1_mj_description";
   hash = "sha256-vm03l9AWxvwJEXgrU0bv8Krf1V1AizHqMxnjXj232K4=";
 }
+// {
+  passthru = {
+    robot = {
+      module = "mc-g1";
+    };
+  };
+}

--- a/pkgs/mc-rtc/mc-mujoco/robots/h1-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/h1-mj-description.nix
@@ -16,3 +16,10 @@ import ./mj-description-base.nix {
   repo = "h1_mj_description";
   hash = "sha256-lplu1x/q/hYHL+Gfz0XdJxBweFBYfmfmZPv9NdlU3VE=";
 }
+// {
+  passthru = {
+    robot = {
+      module = "mc-g1";
+    };
+  };
+}

--- a/pkgs/mc-rtc/mc-mujoco/robots/hrp4-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/hrp4-mj-description.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (_finalAttrs: {
     "-DHONOR_INSTALL_PREFIX=ON"
   ];
 
+  passthru = {
+    robot.module = "mc-hrp4";
+  };
+
   doCheck = true;
 
   meta = with lib; {

--- a/pkgs/mc-rtc/mc-mujoco/robots/hrp4cr-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/hrp4cr-mj-description.nix
@@ -22,6 +22,11 @@ stdenv.mkDerivation (finalAttrs: {
     "-DHONOR_INSTALL_PREFIX=ON"
   ];
 
+  passthru = {
+    # FIXME: does not exist yet
+    robot.module = "mc-hrp4cr";
+  };
+
   doCheck = true;
 
   meta = with lib; {

--- a/pkgs/mc-rtc/mc-mujoco/robots/hrp5p-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/hrp5p-mj-description.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (_finalAttrs: {
     "-DHONOR_INSTALL_PREFIX=ON"
   ];
 
+  passthru = {
+    robot.module = "mc-hrp5-p";
+  };
+
   doCheck = true;
 
   meta = with lib; {

--- a/pkgs/mc-rtc/mc-mujoco/robots/human-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/human-mj-description.nix
@@ -22,6 +22,10 @@ stdenv.mkDerivation (_finalAttrs: {
     "-DHONOR_INSTALL_PREFIX=ON"
   ];
 
+  passthru = {
+    robot.module = "mc-human";
+  };
+
   doCheck = true;
 
   meta = with lib; {

--- a/pkgs/mc-rtc/mc-mujoco/robots/rhps1-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/rhps1-mj-description.nix
@@ -24,6 +24,10 @@ stdenv.mkDerivation (_finalAttrs: {
     "-DHONOR_INSTALL_PREFIX=ON"
   ];
 
+  passthru = {
+    robot.module = "mc-rhps1";
+  };
+
   doCheck = true;
 
   meta = with lib; {

--- a/pkgs/mc-rtc/mc-mujoco/robots/ur5e-mj-description.nix
+++ b/pkgs/mc-rtc/mc-mujoco/robots/ur5e-mj-description.nix
@@ -17,3 +17,10 @@ import ./mj-description-base.nix {
   version = "1.0.0";
   hash = "sha256-HYz9fESWwenMopBHyZIbZWuu2YEwmAEBjjcsSzHgZR0=";
 }
+// {
+  passthru = {
+    robot = {
+      module = "mc-ur5e";
+    };
+  };
+}

--- a/pkgs/mc-rtc/mc-rtc-ticker.nix
+++ b/pkgs/mc-rtc/mc-rtc-ticker.nix
@@ -1,0 +1,48 @@
+/**
+  Convenience derivation to run mc_rtc_ticker through nix run
+*/
+
+# {
+#   lib,
+#   mc-rtc,
+#   # writeShellApplication
+#   buildRosPackage,
+# rosPackages,
+# }:
+# writeShellApplication {
+#   name = "mc-rtc-ticker";
+#   runtimeInputs = [ mc-rtc ];
+#   text = ''
+#     exec ${mc-rtc}/bin/mc_rtc_ticker "$@"
+#   '';
+#   meta = with lib; {
+#     description = "Run mc_rtc_ticker from mc-rtc";
+#     platforms = platforms.linux;
+#   };
+# }
+{
+  lib,
+  writeShellApplication,
+  rosPackages,
+  mc-rtc,
+  rosDistro ? "jazzy",
+}:
+
+let
+  runtimeInputs = [ mc-rtc ];
+  rosEnv = rosPackages.${rosDistro}.buildEnv {
+    paths = runtimeInputs;
+  };
+in
+
+writeShellApplication {
+  name = "mc-rtc-ticker";
+  runtimeInputs = if mc-rtc.with-ros then [ rosEnv ] else runtimeInputs;
+  text = ''
+    exec mc_rtc_ticker "$@"
+  '';
+  meta = with lib; {
+    description = "Run mc_rtc_ticker with ROS environment (no sourcing needed)";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/mc-rtc/mc-rtc-ticker.nix
+++ b/pkgs/mc-rtc/mc-rtc-ticker.nix
@@ -44,5 +44,6 @@ writeShellApplication {
   meta = with lib; {
     description = "Run mc_rtc_ticker with ROS environment (no sourcing needed)";
     platforms = platforms.linux;
+    mainProgram = "mc-rtc-ticker";
   };
 }

--- a/pkgs/mc-rtc/mc-rtc-ticker.nix
+++ b/pkgs/mc-rtc/mc-rtc-ticker.nix
@@ -21,7 +21,6 @@
 #   };
 # }
 {
-  lib,
   writeShellApplication,
   rosPackages,
   mc-rtc,
@@ -41,9 +40,8 @@ writeShellApplication {
   text = ''
     exec mc_rtc_ticker "$@"
   '';
-  meta = with lib; {
+  meta = {
     description = "Run mc_rtc_ticker with ROS environment (no sourcing needed)";
-    platforms = platforms.linux;
     mainProgram = "mc-rtc-ticker";
   };
 }

--- a/pkgs/mc-rtc/mk-mc-rtc-controller.nix
+++ b/pkgs/mc-rtc/mk-mc-rtc-controller.nix
@@ -1,7 +1,7 @@
 /**
   # mkMcRtcController
 
-  A wrapper for `stdenv.mkDerivation` that adds mc-rtc-specific metadata, generates a `mc_rtc.yaml` configuration file in the Nix store, and exposes all mc-rtc-related attributes under a single `mcRtc` attribute set in `passthru`.
+  A wrapper for `stdenv.mkDerivation` that adds mc-rtc-specific metadata, generates a `mc_rtc.yaml` configuration file in the Nix store, and exposes all mc-rtc-related attributes under a single `mc-rtc` attribute set in `passthru`.
 
   ## Usage
 
@@ -36,7 +36,7 @@
       license = licenses.bsd2;
       platforms = platforms.all;
     };
-    mcRtc = {
+    passthru.mc-rtc = {
       plugins = [
         footsteps-planner-plugin
         mc-joystick-plugin
@@ -63,7 +63,7 @@
   ## Arguments
 
   - All standard `stdenv.mkDerivation` arguments are supported.
-  - `mcRtc` (attribute set): mc-rtc-specific metadata.
+  - `mc-rtc` (attribute set): mc-rtc-specific metadata.
     - `plugins` (list): List of plugin derivations or names.
     - `observers` (list): List of observer derivations or names.
     - `controller` (attribute set): Controller configuration (e.g., `Enabled`, `MainRobot`).
@@ -71,12 +71,12 @@
 
   ## Output
 
-  The returned derivation has a `passthru.mcRtc` attribute set containing:
+  The returned derivation has a `passthru.mc-rtc` attribute set containing:
   - `plugins`
   - `observers`
   - `controller`
   - `suggests`
-  - `mcRtcYaml`: Path to the generated `mc_rtc.yaml` file in the Nix store.
+  - `mc-rtcYaml`: Path to the generated `mc_rtc.yaml` file in the Nix store.
   - `shellHook`: A shell hook that sets `MC_RTC_CONTROLLER_CONFIG` and `LD_LIBRARY_PATH`.
 
   ## Example
@@ -93,41 +93,61 @@
   lib,
 }:
 
+# excepts mc-rtc in passthru
 {
-  mcRtc,
+  passthru ? { },
   ...
 }@args:
 
 let
+  mc-rtc = passthru.mc-rtc;
   isStrOrDrv = x: lib.isString x || lib.isDerivation x;
 
   assertValidMcRtc =
-    mcRtc:
+    mc-rtc:
     lib.assertMsg (lib.all isStrOrDrv (
-      mcRtc.plugins or [ ]
-    )) "mcRtc.plugins must be a list of strings or derivations"
+      mc-rtc.plugins or [ ]
+    )) "mc-rtc.plugins must be a list of strings or derivations"
     && lib.assertMsg (lib.all lib.isString (
-      mcRtc.observers or [ ]
-    )) "mcRtc.observers must be a list of strings"
+      mc-rtc.observers or [ ]
+    )) "mc-rtc.observers must be a list of strings"
     && lib.assertMsg (lib.all isStrOrDrv (
-      (mcRtc.suggests or { }).robots or [ ]
-    )) "mcRtc.suggests.robots must be a list of strings or derivations"
+      (mc-rtc.suggests or { }).robots or [ ]
+    )) "mc-rtc.suggests.robots must be a list of strings or derivations"
     && lib.assertMsg (lib.all isStrOrDrv (
-      (mcRtc.suggests or { }).apps or [ ]
-    )) "mcRtc.suggests.apps must be a list of strings or derivations"
+      (mc-rtc.suggests or { }).apps or [ ]
+    )) "mc-rtc.suggests.apps must be a list of strings or derivations"
     && lib.assertMsg (lib.all isStrOrDrv (
-      mcRtc.runApps or [ ]
-    )) "mcRtc.runApps must be a list of strings or derivations";
+      mc-rtc.runApps or [ ]
+    )) "mc-rtc.runApps must be a list of strings or derivations";
 
-  args' = removeAttrs args [ "mcRtc" ];
+  args' = removeAttrs args [ "mc-rtc" ];
 in
 stdenv.mkDerivation (
   args'
   // {
     passthru = {
-      mcRtc = mcRtc // {
+      mc-rtc = mc-rtc // {
+        isController = true;
+
+        runAllAppsScript = ''
+          #!/usr/bin/env bash
+          set -e
+          if [ "$#" -eq 0 ]; then
+            echo "Usage: $0 app1 [app2 ...]"
+            exit 1
+          fi
+          pids=""
+          trap 'echo "Stopping apps..."; [ -n "$pids" ] && kill $pids 2>/dev/null || true; exit' INT
+          for app in "$@"; do
+            echo "Starting $app"
+            "$app" &
+            pids="$pids $!"
+          done
+          wait
+        '';
       };
     };
-    __asserts = assertValidMcRtc mcRtc;
+    __asserts = assertValidMcRtc mc-rtc;
   }
 )

--- a/pkgs/mc-rtc/mk-mc-rtc-controller.nix
+++ b/pkgs/mc-rtc/mk-mc-rtc-controller.nix
@@ -129,23 +129,6 @@ stdenv.mkDerivation (
     passthru = {
       mc-rtc = mc-rtc // {
         isController = true;
-
-        runAllAppsScript = ''
-          #!/usr/bin/env bash
-          set -e
-          if [ "$#" -eq 0 ]; then
-            echo "Usage: $0 app1 [app2 ...]"
-            exit 1
-          fi
-          pids=""
-          trap 'echo "Stopping apps..."; [ -n "$pids" ] && kill $pids 2>/dev/null || true; exit' INT
-          for app in "$@"; do
-            echo "Starting $app"
-            "$app" &
-            pids="$pids $!"
-          done
-          wait
-        '';
       };
     };
     __asserts = assertValidMcRtc mc-rtc;

--- a/pkgs/mc-rtc/mk-mc-rtc-controller.nix
+++ b/pkgs/mc-rtc/mk-mc-rtc-controller.nix
@@ -1,0 +1,132 @@
+/**
+  # mkMcRtcController
+
+  A wrapper for `stdenv.mkDerivation` that adds mc-rtc-specific metadata, generates a `mc_rtc.yaml` configuration file in the Nix store, and exposes all mc-rtc-related attributes under a single `mcRtc` attribute set in `passthru`.
+
+  ## Usage
+
+  ```nix
+  let
+    mkController = import ./pkgs/mc-rtc/mkController.nix { inherit lib pkgs; };
+  in
+  mkMcRtcController {
+    pname = "ismpc-walking-controller";
+    version = "0.1.0";
+    src = fetchFromGitHub {
+      owner = "jrl-umi3218";
+      repo = "lipm_walking_controller";
+      tag = "v0.1.0";
+      hash = "sha256-tPWzbxuJbJm5zlUzU8jQJSdTIOsW8mb/Ci2DOeFdr4M=";
+    };
+    buildInputs = [ jrl-cmakemodulesv2 ];
+    nativeBuildInputs = [ cmake ];
+    propagatedBuildInputs = [
+      mc-rtc
+      pendulum-feasibility-solver
+      mc-joystick-plugin
+    ];
+    cmakeFlags = [
+      "-DINSTALL_DOCUMENTATION=OFF"
+      "-DMC_RTC_HONOR_INSTALL_PREFIX=ON"
+    ];
+    doCheck = true;
+    meta = with lib; {
+      description = "Walking controller based on linear inverted pendulum tracking";
+      homepage = "https://github.com/isri-aist/ismpc_walking";
+      license = licenses.bsd2;
+      platforms = platforms.all;
+    };
+    mcRtc = {
+      plugins = [
+        footsteps-planner-plugin
+        mc-joystick-plugin
+      ];
+      observers = [ "mc-state-observation" ];
+      controller = {
+        Enabled = "ismpc_walking";
+        MainRobot = "JVRC1";
+      };
+      suggests = {
+        robots = [
+          "mc-hrp4"
+          "mc-hrp2"
+          "mc-hrp5-p"
+          "mc-rhps1"
+          "mc-hrp4cr"
+        ];
+        apps = [ "mc-mujoco" ];
+      };
+    };
+  }
+  ```
+
+  ## Arguments
+
+  - All standard `stdenv.mkDerivation` arguments are supported.
+  - `mcRtc` (attribute set): mc-rtc-specific metadata.
+    - `plugins` (list): List of plugin derivations or names.
+    - `observers` (list): List of observer derivations or names.
+    - `controller` (attribute set): Controller configuration (e.g., `Enabled`, `MainRobot`).
+    - `suggests` (attribute set): Suggested robots and apps.
+
+  ## Output
+
+  The returned derivation has a `passthru.mcRtc` attribute set containing:
+  - `plugins`
+  - `observers`
+  - `controller`
+  - `suggests`
+  - `mcRtcYaml`: Path to the generated `mc_rtc.yaml` file in the Nix store.
+  - `shellHook`: A shell hook that sets `MC_RTC_CONTROLLER_CONFIG` and `LD_LIBRARY_PATH`.
+
+  ## Example
+
+  To use the generated YAML in a shell:
+
+  ```sh
+  nix develop .#ismpc-walking-controller
+  # The environment variable MC_RTC_CONTROLLER_CONFIG will point to the YAML file.
+  ```
+*/
+{
+  stdenv,
+  lib,
+  pkgs,
+}:
+
+{
+  mcRtc ? { },
+  ...
+}@args:
+
+let
+  controller = mcRtc.controller or { };
+
+  mcRtcYamlTemplate = pkgs.writeText "${args.pname or "controller"}-mc_rtc.yaml.in" ''
+    ---
+    ${lib.optionalString (controller ? MainRobot) "MainRobot: \"${controller.MainRobot}\""}
+    ${lib.optionalString (controller ? Enabled) "Enabled: \"${controller.Enabled}\""}
+    ControllerModulePaths: ["@out@/lib/mc_controller"]
+    RobotModulePaths: ["@out@/lib/mc_robots"]
+    ObserverModulePaths: ["@out@/lib/mc_observers"]
+    GlobalPluginPaths: ["@out@/lib/mc_plugins"]
+    LoadUserConfiguration: false
+  '';
+  args' = builtins.removeAttrs args [ "mcRtc" ];
+in
+stdenv.mkDerivation (
+  args'
+  // {
+    passthru = {
+      mcRtc = mcRtc // {
+        # access it as ${drv}/${mcRtcYaml}
+        mcRtcYaml = "share/mc_rtc.yaml";
+      };
+    };
+
+    postInstall = ''
+      mkdir -p $out/share
+      sed "s|@out@|$out|g" ${mcRtcYamlTemplate} > $out/share/mc_rtc.yaml
+    '';
+  }
+)

--- a/pkgs/mc-rtc/mk-mc-rtc-controller.nix
+++ b/pkgs/mc-rtc/mk-mc-rtc-controller.nix
@@ -91,42 +91,43 @@
 {
   stdenv,
   lib,
-  pkgs,
 }:
 
 {
-  mcRtc ? { },
+  mcRtc,
   ...
 }@args:
 
 let
-  controller = mcRtc.controller or { };
+  isStrOrDrv = x: lib.isString x || lib.isDerivation x;
 
-  mcRtcYamlTemplate = pkgs.writeText "${args.pname or "controller"}-mc_rtc.yaml.in" ''
-    ---
-    ${lib.optionalString (controller ? MainRobot) "MainRobot: \"${controller.MainRobot}\""}
-    ${lib.optionalString (controller ? Enabled) "Enabled: \"${controller.Enabled}\""}
-    ControllerModulePaths: ["@out@/lib/mc_controller"]
-    RobotModulePaths: ["@out@/lib/mc_robots"]
-    ObserverModulePaths: ["@out@/lib/mc_observers"]
-    GlobalPluginPaths: ["@out@/lib/mc_plugins"]
-    LoadUserConfiguration: false
-  '';
-  args' = builtins.removeAttrs args [ "mcRtc" ];
+  assertValidMcRtc =
+    mcRtc:
+    lib.assertMsg (lib.all isStrOrDrv (
+      mcRtc.plugins or [ ]
+    )) "mcRtc.plugins must be a list of strings or derivations"
+    && lib.assertMsg (lib.all lib.isString (
+      mcRtc.observers or [ ]
+    )) "mcRtc.observers must be a list of strings"
+    && lib.assertMsg (lib.all isStrOrDrv (
+      (mcRtc.suggests or { }).robots or [ ]
+    )) "mcRtc.suggests.robots must be a list of strings or derivations"
+    && lib.assertMsg (lib.all isStrOrDrv (
+      (mcRtc.suggests or { }).apps or [ ]
+    )) "mcRtc.suggests.apps must be a list of strings or derivations"
+    && lib.assertMsg (lib.all isStrOrDrv (
+      mcRtc.runApps or [ ]
+    )) "mcRtc.runApps must be a list of strings or derivations";
+
+  args' = removeAttrs args [ "mcRtc" ];
 in
 stdenv.mkDerivation (
   args'
   // {
     passthru = {
       mcRtc = mcRtc // {
-        # access it as ${drv}/${mcRtcYaml}
-        mcRtcYaml = "share/mc_rtc.yaml";
       };
     };
-
-    postInstall = ''
-      mkdir -p $out/share
-      sed "s|@out@|$out|g" ${mcRtcYamlTemplate} > $out/share/mc_rtc.yaml
-    '';
+    __asserts = assertValidMcRtc mcRtc;
   }
 )

--- a/pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix
+++ b/pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix
@@ -61,7 +61,7 @@ buildRosPackage {
     export ROS_VERSION=2
   '';
 
-  passthu = {
+  passthru = {
     inherit fetched;
   };
 

--- a/pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix
+++ b/pkgs/mc-rtc/ros/mc-rtc-rviz-panel.nix
@@ -61,6 +61,10 @@ buildRosPackage {
     export ROS_VERSION=2
   '';
 
+  passthu = {
+    inherit fetched;
+  };
+
   meta = {
     description = "Tools for the mc_rtc framework built around ROS (rviz panel, etc)";
     homepage = "https://github.com/jrl-umi3218/mc_rtc_ros";

--- a/pkgs/mc-rtc/ros/mc-rtc-rviz.nix
+++ b/pkgs/mc-rtc/ros/mc-rtc-rviz.nix
@@ -3,7 +3,6 @@
   buildRosPackage,
   ament-cmake,
   runtimeShell,
-  fetchFromGitHub,
   mc-rtc-rviz-panel,
   ros2cli,
   ros2launch,
@@ -11,28 +10,11 @@
   ros2topic,
 }:
 
-let
-  pname = "mc-rtc-ticker";
-  version = "1.6.1";
-  fetched =
-    # fetchFromGitHub {
-    #   owner = "jrl-umi3218";
-    #   repo = "mc_rtc_ros";
-    #   rev = "227917d348971b3ba39e7dcef0df4ca65c6bf511";
-    #   sha256 = "sha256-40gtvLRzFi7Rd9BwiX3P/OWqH2fUCuZoUO53zYJdwzc=";
-    # };
-    fetchFromGitHub {
-      owner = "arntanguy";
-      repo = "mc_rtc_ros";
-      rev = "topic/nix";
-      hash = "sha256-Gmxv/nYKGcK9G1r0i08kLzTc2Dj8qCAQA/S0bic1LKA=";
-    };
-in
 buildRosPackage {
-  pname = "${pname}";
-  version = "${version}";
+  pname = "mc-rtc-rviz";
+  version = "${mc-rtc-rviz-panel.version}";
 
-  src = "${fetched}/mc_rtc_ticker";
+  src = "${mc-rtc-rviz-panel.fetched}/mc_rtc_ticker";
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];

--- a/templates/controller/flake.nix
+++ b/templates/controller/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "mc-rtc-superbuild release and development shells";
+  description = "mc-rtc-superbuild release and development shells for a controller";
 
   inputs = {
     mc-rtc-nix.url = "github:mc-rtc/nixpkgs";
@@ -14,74 +14,28 @@
 
   outputs =
     inputs:
-    inputs.flake-parts.lib.mkFlake { inherit inputs; } (
-      { ... }:
+    /**
+      This will:
+      - Build the controller from the local sources in this repository
+      - Generate two mc-rtc-superbuild development shells:
+        - mc-rtc-superbuild-controller-name : a release shell allowing to run the controller
+        - mc-rtc-superbuild-controller-name-devel : a development shell allowing to build the controller and run it
+        Instructions are displayed upon entering the shells.
+
+       You can control the behaviour or define your own shells with:
+       mc-rtc-nix = {};
+       mc-rtc-superbuild = {};
+
+       Note that the mc-rtc-superbuild attribute set will be merged with the default controller configuration
+    */
+    inputs.mc-rtc-nix.lib.mkMcRtcController inputs "CHANGEME-CONTROLLER-NAME" (
+      { lib, ... }:
       {
-        systems = import inputs.systems;
-        imports = [
-          inputs.mc-rtc-nix.flakeModule
-          {
-            # This mc-rtc-superbuild configuration will:
-            # - Define named reusable configurations in `configurations`
-            # - Use explicit runtime (Nix runtime components) vs devel (local/source overlays)
-            # - Generate `${project.name}-<configuration>` and `${project.name}-<configuration>-devel` shells
-            #
-            # This will also generate a .superbuild/mc_rtc.yaml file containg the suitable mc_rtc configuration
-            # Devel dependencies are expected to be installed manually in .superbuild/install
-            #
-            # As always, individual packages can be overridden using flakoboros
-            mc-rtc-superbuild =
-              { pkgs, ... }:
-              {
-                enable = true;
-                project.pname = "";
-                # TODO: replace this section with your own configuration presets for your project
-                configurations = {
-                  your-project-minimal = {
-                    extends = [ "minimal" ];
-                    runtime = {
-                      robots = [
-                        pkgs.mc-panda-lirmm
-                        pkgs.mc-panda
-                      ];
-
-                      apps = [
-                        pkgs.mc-rtc-magnum
-                      ];
-                      config = "lib/mc_controller/etc/your-project/mc_rtc.yaml";
-                    };
-                    devel = {
-                      config = "lib64/mc_controller/etc/your-project/mc_rtc.yaml";
-                      controllers = [ pkgs.your-project ];
-                      plugins = [ pkgs.your-project ];
-                      robots = [ pkgs.your-project ];
-                    };
-                  };
-                  your-project-full = {
-                    extends = [
-                      "default"
-                      "your-project-minimal"
-                    ];
-                    runtime = {
-                      apps = [
-                        pkgs.mc-franka
-                      ];
-                    };
-                  };
-                };
-              };
-
-            flakoboros = {
-              # # Override all dependencies
-              # # They are locked in flake.lock to the latest commit available at the time
-              # # To update to all inputs' latest commit, use
-              # # nix flake update
-              # overrideAttrs.your-repository = {
-              #   src = inputs.your-repository;
-              # };
-            };
-          }
-        ];
+        flakoboros = {
+          overrideAttrs.CHANGEME-CONTROLLER-NAME = {
+            src = lib.cleanSource ./.;
+          };
+        };
       }
     );
 }

--- a/templates/superbuild/.github/dependabot.yml
+++ b/templates/superbuild/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/templates/superbuild/.github/workflows/nix.yml
+++ b/templates/superbuild/.github/workflows/nix.yml
@@ -1,0 +1,39 @@
+name: "CI - Nix"
+on:
+  push:
+    branches:
+      - devel
+      - master
+      - main
+  pull_request:
+    branches:
+      - devel
+      - master
+      - main
+jobs:
+  nix:
+    runs-on: "${{ matrix.os }}-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v17
+        with:
+          name: mc-rtc-nix
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          extraPullNames: "ros,gepetto"
+      - run: nix flake check -L
+      - run: nix build -L
+  check:
+    if: always()
+    name: check-macos-linux-nix
+    runs-on: ubuntu-latest
+    needs:
+      - nix
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/templates/superbuild/.github/workflows/update-flake-lock.yml
+++ b/templates/superbuild/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,32 @@
+name: update-flake-lock
+on:
+  workflow_dispatch:
+  schedule:
+    # runs at 2:00 AM on the 25th day of every month
+    - cron: '0 2 25 * *'
+jobs:
+  update-flake-inputs:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MC_RTC_NIX_APP_ID }}
+          private-key: ${{ secrets.MC_RTC_NIX_APP_PRIVATE_KEY }}
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Setup Nix
+        uses: cachix/install-nix-action@v31
+      - name: Update flake inputs
+        uses: mic92/update-flake-inputs@v1
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          pr-labels: 'no-changelog'
+          git-author-name: 'arntanguy[bot]'
+          git-author-email: '67139+arntanguy@users.noreply.github.com'

--- a/templates/superbuild/.gitignore
+++ b/templates/superbuild/.gitignore
@@ -1,0 +1,4 @@
+.superbuild/
+build
+build/
+.direnv/

--- a/templates/superbuild/.mergify.yml
+++ b/templates/superbuild/.mergify.yml
@@ -1,0 +1,29 @@
+pull_request_rules:
+  # automatically queues when a bot pr succeeds (see queue_rules)
+  - name: merge [bot] PRs when CI pass
+    conditions:
+      - or:
+        - author = dependabot[bot]
+        - author = gepetto-flake-updater[bot]
+        - author = mc-rtc-nixpkgs-flake-updater[bot]
+        - author = github-actions[bot]
+        - author = pre-commit-ci[bot]
+    actions:
+      queue:
+
+  # runs when commenting @mergifyio queue
+  - name: queue PRs with "queue" label when all CI checks pass
+    conditions:
+      - label = queued
+    actions:
+      queue:
+
+# ensure that required CI jobs suceed
+queue_rules:
+  - name: default
+    merge_conditions:
+      - check-success = "check-macos-linux-nix"
+
+merge_queue:
+  queue_controls_comment: false
+

--- a/templates/superbuild/.pre-commit-config.yaml
+++ b/templates/superbuild/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+ci:
+  autoupdate_schedule: quarterly
+repos:
+  - repo: https://github.com/BlankSpruce/gersemi
+    rev: 0.26.1
+    hooks:
+      - id: gersemi
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.9
+    hooks:
+      - id: ruff-check
+      - id: ruff-format
+  - repo: https://github.com/pappasam/toml-sort
+    rev: v0.24.4
+    hooks:
+      - id: toml-sort-fix
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v22.1.2
+    hooks:
+      - id: clang-format
+        args:
+          - --style=Google
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+      - id: destroyed-symlinks
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: fix-byte-order-marker
+      - id: mixed-line-ending
+      - id: trailing-whitespace

--- a/templates/superbuild/flake.nix
+++ b/templates/superbuild/flake.nix
@@ -1,0 +1,89 @@
+{
+  description = "mc-rtc-superbuild release and development shells";
+
+  inputs = {
+    mc-rtc-nix.url = "github:mc-rtc/nixpkgs";
+    flake-parts.follows = "mc-rtc-nix/flake-parts";
+    systems.follows = "mc-rtc-nix/systems";
+
+    # You can override dependencies from a commit/pull request by:
+    # Adding it as input
+    # your-repository.url = "github:username/repository/pull/ID/head";
+    # your-repository.flake = true; # use false if the repository does not have a flake
+  };
+
+  outputs =
+    inputs:
+    /**
+      This will:
+      - Build the controller from the local sources in this repository
+      - Generate mc-rtc-superbuild development shells from named configurations in 'configurations':
+        - mc-rtc-superbuild-controller-<configuration>: a release shell allowing to run the controller
+        - mc-rtc-superbuild-controller-<configuration>-devel : a development shell allowing to build the controller and run it
+        Instructions are displayed upon entering the shells.
+
+       You can control the behaviour or define your own shells with:
+       mc-rtc-nix = {};
+       mc-rtc-superbuild = {};
+
+       This will also generate a mc_rtc.yaml file in $MC_RTC_CONTROLLER_CONFIG containg the suitable mc_rtc configuration
+       Devel dependencies are expected to be installed manually in .superbuild/install
+    */
+    inputs.mc-rtc-nix.lib.mkMcRtcModule inputs (
+      { lib, ... }:
+      {
+        #
+        # As always, individual packages can be overridden using flakoboros
+        mc-rtc-superbuild =
+          { pkgs, ... }:
+          {
+            enable = true;
+            project.pname = "";
+            # TODO: replace this section with your own configuration presets for your project
+            configurations = {
+              your-project-minimal = {
+                extends = [ "minimal" ];
+                runtime = {
+                  robots = [
+                    pkgs.mc-panda-lirmm
+                    pkgs.mc-panda
+                  ];
+
+                  apps = [
+                    pkgs.mc-rtc-magnum
+                  ];
+                  config = "lib/mc_controller/etc/your-project/mc_rtc.yaml";
+                };
+                devel = {
+                  config = "lib64/mc_controller/etc/your-project/mc_rtc.yaml";
+                  controllers = [ pkgs.your-project ];
+                  plugins = [ pkgs.your-project ];
+                  robots = [ pkgs.your-project ];
+                };
+              };
+              your-project-full = {
+                extends = [
+                  "default"
+                  "your-project-minimal"
+                ];
+                runtime = {
+                  apps = [
+                    pkgs.mc-franka
+                  ];
+                };
+              };
+            };
+          };
+
+        flakoboros = {
+          # Override dependencies
+          # They are locked in flake.lock to the latest commit available at the time
+          # To update to all inputs' latest commit, use
+          # nix flake update
+          overrideAttrs.your-project = {
+            src = lib.cleanSource ./.;
+          };
+        };
+      }
+    );
+}

--- a/templates/superbuild/flakoboros/.github/dependabot.yml
+++ b/templates/superbuild/flakoboros/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/templates/superbuild/flakoboros/.github/workflows/nix.yml
+++ b/templates/superbuild/flakoboros/.github/workflows/nix.yml
@@ -1,0 +1,39 @@
+name: "CI - Nix"
+on:
+  push:
+    branches:
+      - devel
+      - master
+      - main
+  pull_request:
+    branches:
+      - devel
+      - master
+      - main
+jobs:
+  nix:
+    runs-on: "${{ matrix.os }}-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v17
+        with:
+          name: mc-rtc-nix
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          extraPullNames: "ros,gepetto"
+      - run: nix flake check -L
+      - run: nix build -L
+  check:
+    if: always()
+    name: check-macos-linux-nix
+    runs-on: ubuntu-latest
+    needs:
+      - nix
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/templates/superbuild/flakoboros/.github/workflows/update-flake-lock.yml
+++ b/templates/superbuild/flakoboros/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,32 @@
+name: update-flake-lock
+on:
+  workflow_dispatch:
+  schedule:
+    # runs at 2:00 AM on the 25th day of every month
+    - cron: '0 2 25 * *'
+jobs:
+  update-flake-inputs:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MC_RTC_NIX_APP_ID }}
+          private-key: ${{ secrets.MC_RTC_NIX_APP_PRIVATE_KEY }}
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Setup Nix
+        uses: cachix/install-nix-action@v31
+      - name: Update flake inputs
+        uses: mic92/update-flake-inputs@v1
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          pr-labels: 'no-changelog'
+          git-author-name: 'arntanguy[bot]'
+          git-author-email: '67139+arntanguy@users.noreply.github.com'

--- a/templates/superbuild/flakoboros/.gitignore
+++ b/templates/superbuild/flakoboros/.gitignore
@@ -1,0 +1,4 @@
+build
+build/
+.direnv/
+result

--- a/templates/superbuild/flakoboros/.mergify.yml
+++ b/templates/superbuild/flakoboros/.mergify.yml
@@ -1,0 +1,27 @@
+pull_request_rules:
+  # automatically queues when a bot pr succeeds (see queue_rules)
+  - name: merge [bot] PRs when CI pass
+    conditions:
+      - or:
+        - author = dependabot[bot]
+        - author = gepetto-flake-updater[bot]
+        - author = mc-rtc-nixpkgs-flake-updater[bot]
+        - author = github-actions[bot]
+        - author = pre-commit-ci[bot]
+    actions:
+      queue:
+
+  # runs when commenting @mergifyio queue
+  - name: queue PRs with "queue" label when all CI checks pass
+    conditions:
+      - label = queued
+    actions:
+      queue:
+
+# ensure that required CI jobs suceed
+queue_rules:
+  - name: default
+    merge_conditions:
+      - check-success = "check-macos-linux-nix"
+merge_queue:
+  queue_controls_comment: false

--- a/templates/superbuild/flakoboros/.pre-commit-config.yaml
+++ b/templates/superbuild/flakoboros/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+ci:
+  autoupdate_schedule: quarterly
+repos:
+  - repo: https://github.com/BlankSpruce/gersemi
+    rev: 0.26.1
+    hooks:
+      - id: gersemi
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.9
+    hooks:
+      - id: ruff-check
+      - id: ruff-format
+  - repo: https://github.com/pappasam/toml-sort
+    rev: v0.24.4
+    hooks:
+      - id: toml-sort-fix
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v22.1.2
+    hooks:
+      - id: clang-format
+        args:
+          - --style=Google
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+      - id: destroyed-symlinks
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: fix-byte-order-marker
+      - id: mixed-line-ending
+      - id: trailing-whitespace

--- a/templates/superbuild/flakoboros/flake.nix
+++ b/templates/superbuild/flakoboros/flake.nix
@@ -1,0 +1,21 @@
+{
+  description = "CHANGEME";
+
+  inputs.mc-rtc-nix.url = "github:mc-rtc/nixpkgs";
+
+  outputs =
+    inputs:
+    inputs.mc-rtc-nix.lib.mkFlakoboros inputs (
+      { lib, ... }:
+      {
+        overrideAttrs.CHANGEME = {
+          src = lib.fileset.toSource {
+            root = ./.;
+            fileset = lib.fileset.unions [
+              ./CHANGEME
+            ];
+          };
+        };
+      }
+    );
+}


### PR DESCRIPTION
Closes #74 

Large usability upgrade:
- Controllers are now expected to provide their required runtime dependencies (plugins, robots, etc) in `passthru.mc-rtc`
- Controllers can now suggest runtime dependencies in `passthru.mc-rtc.suggests`.
- Introduce a library. In particular `lib.mkControllerSuperbuild` will generate a confguration suitable for mc-rtc-superbuild devshell generation from `passthu.mc-rtc`
- Simplify boilerplate in user flakes with `mkMcRtcModule` and `mkMcRtcController`. The later provides auto-generated devshells providing a superbuild environment generated from the controller's `passthru.mc-rtc`

For example, we can now do:

```nix
{
  description = "ismpc-walking-controller";

  inputs = {
    mc-rtc-nix.url = "github:mc-rtc/nixpkgs";
    flake-parts.follows = "mc-rtc-nix/flake-parts";
    systems.follows = "mc-rtc-nix/systems";
    gepetto.follows = "mc-rtc-nix/gepetto";
    private-trigger.url = "github:boolean-option/false";
  };

  outputs =
    inputs:
    inputs.mc-rtc-nix.lib.mkMcRtcController inputs "ismpc-walking-controller" (
      { lib, ... }:
      {
        mc-rtc-nix.overlays.private = inputs.private-trigger.value;
        flakoboros = {
          overrideAttrs.ismpc-walking-controller = {
            src = lib.cleanSource ./.;
          };
        };
      }
    );
}
```

To get:
- Development shells:
  - mc-rtc-superbuild-ismpc-walking-controller
    - In additions controllers can now specify `passthru.mc-rtc.runApps` that is used to generate a script providing a default way to run the controller.
  - mc-rtc-superbuild-ismpc-walking-controller-devel
- Flakoboros ability to easily override any dependency

In addition, fix ccache usage for derivations that do not use `stdenv` directly, that is `buildRosPackage` (this includes mc-rtc itself!). ccache is now used by default. 
